### PR TITLE
Rename DIVIDE_BY_ZERO_ERROR to BAD_VALUE_ERROR

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/expressions/arithmetic/divide/test_operator_divide.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/arithmetic/divide/test_operator_divide.py
@@ -10,7 +10,7 @@ from documentdb_tests.compatibility.tests.core.operator.expressions.utils.utils 
     execute_expression_with_insert,
 )
 from documentdb_tests.framework.assertions import assertResult
-from documentdb_tests.framework.error_codes import DIVIDE_BY_ZERO_ERROR, TYPE_MISMATCH_ERROR
+from documentdb_tests.framework.error_codes import BAD_VALUE_ERROR, TYPE_MISMATCH_ERROR
 from documentdb_tests.framework.test_case import BaseTestCase
 from documentdb_tests.framework.test_constants import (
     DECIMAL128_HALF,
@@ -662,42 +662,42 @@ DIVIDE_TESTS: list[DivideTest] = [
         "zero_divisor",
         dividend=10,
         divisor=0,
-        error_code=DIVIDE_BY_ZERO_ERROR,
+        error_code=BAD_VALUE_ERROR,
         msg="Should reject division by zero int",
     ),
     DivideTest(
         "zero_divisor_double",
         dividend=10,
         divisor=0.0,
-        error_code=DIVIDE_BY_ZERO_ERROR,
+        error_code=BAD_VALUE_ERROR,
         msg="Should reject division by zero double",
     ),
     DivideTest(
         "decimal_zero_divisor",
         dividend=Decimal128("10"),
         divisor=Decimal128("0"),
-        error_code=DIVIDE_BY_ZERO_ERROR,
+        error_code=BAD_VALUE_ERROR,
         msg="Should reject division by zero decimal128",
     ),
     DivideTest(
         "zero_div_zero",
         dividend=0,
         divisor=0,
-        error_code=DIVIDE_BY_ZERO_ERROR,
+        error_code=BAD_VALUE_ERROR,
         msg="Should reject 0/0",
     ),
     DivideTest(
         "zero_double_div_zero",
         dividend=0.0,
         divisor=0.0,
-        error_code=DIVIDE_BY_ZERO_ERROR,
+        error_code=BAD_VALUE_ERROR,
         msg="Should reject 0.0/0.0",
     ),
     DivideTest(
         "decimal_zero_div_zero",
         dividend=Decimal128("0"),
         divisor=Decimal128("0"),
-        error_code=DIVIDE_BY_ZERO_ERROR,
+        error_code=BAD_VALUE_ERROR,
         msg="Should reject decimal 0/0",
     ),
 ]

--- a/documentdb_tests/framework/error_codes.py
+++ b/documentdb_tests/framework/error_codes.py
@@ -3,7 +3,7 @@ Error Codes expected from the server.
 Keep sorted by error code number. No duplicates.
 """
 
-DIVIDE_BY_ZERO_ERROR = 2
+BAD_VALUE_ERROR = 2
 TYPE_MISMATCH_ERROR = 14
 EXPRESSION_TYPE_MISMATCH_ERROR = 16020
 MODULO_ZERO_REMAINDER_ERROR = 16610


### PR DESCRIPTION
Error code 2 is a more general `BAD_VALUE_ERROR`, not specific to divide-by-zero. This change renames it to match the more general purpose, so future uses of this error code don't need a separate constant.

For example, the `{"$match": {"$fakeOperator": 1}}` pipeline returns the same error code.

Relates to #34 