### PR TITLE
Stop wrapping expected value in assertResult

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/expressions/arithmetic/divide/test_operator_divide.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/arithmetic/divide/test_operator_divide.py
@@ -6,10 +6,10 @@ import pytest
 from bson import Decimal128, Int64
 
 from documentdb_tests.compatibility.tests.core.operator.expressions.utils.utils import (
+    assert_expression_result,
     execute_expression,
     execute_expression_with_insert,
 )
-from documentdb_tests.framework.assertions import assertResult
 from documentdb_tests.framework.error_codes import DIVIDE_BY_ZERO_ERROR, TYPE_MISMATCH_ERROR
 from documentdb_tests.framework.test_case import BaseTestCase
 from documentdb_tests.framework.test_constants import (
@@ -707,11 +707,8 @@ DIVIDE_TESTS: list[DivideTest] = [
 def test_divide_literal(collection, test):
     """Test $divide from literals"""
     result = execute_expression(collection, {"$divide": [test.dividend, test.divisor]})
-    assertResult(
-        result,
-        expected=[{"result": test.expected}],
-        error_code=test.error_code,
-        msg=test.msg,
+    assert_expression_result(
+        result, expected=test.expected, error_code=test.error_code, msg=test.msg
     )
 
 
@@ -727,11 +724,8 @@ def test_divide_insert(collection, test):
         {"$divide": ["$dividend", "$divisor"]},
         {"dividend": test.dividend, "divisor": test.divisor},
     )
-    assertResult(
-        result,
-        expected=[{"result": test.expected}],
-        error_code=test.error_code,
-        msg=test.msg,
+    assert_expression_result(
+        result, expected=test.expected, error_code=test.error_code, msg=test.msg
     )
 
 
@@ -743,9 +737,6 @@ def test_divide_mixed(collection, test):
     result = execute_expression_with_insert(
         collection, {"$divide": ["$dividend", test.divisor]}, {"dividend": test.dividend}
     )
-    assertResult(
-        result,
-        expected=[{"result": test.expected}],
-        error_code=test.error_code,
-        msg=test.msg,
+    assert_expression_result(
+        result, expected=test.expected, error_code=test.error_code, msg=test.msg
     )

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/arithmetic/divide/test_operator_divide.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/arithmetic/divide/test_operator_divide.py
@@ -707,7 +707,12 @@ DIVIDE_TESTS: list[DivideTest] = [
 def test_divide_literal(collection, test):
     """Test $divide from literals"""
     result = execute_expression(collection, {"$divide": [test.dividend, test.divisor]})
-    assertResult(result, expected=test.expected, error_code=test.error_code, msg=test.msg)
+    assertResult(
+        result,
+        expected=[{"result": test.expected}],
+        error_code=test.error_code,
+        msg=test.msg,
+    )
 
 
 @pytest.mark.parametrize(
@@ -722,7 +727,12 @@ def test_divide_insert(collection, test):
         {"$divide": ["$dividend", "$divisor"]},
         {"dividend": test.dividend, "divisor": test.divisor},
     )
-    assertResult(result, expected=test.expected, error_code=test.error_code, msg=test.msg)
+    assertResult(
+        result,
+        expected=[{"result": test.expected}],
+        error_code=test.error_code,
+        msg=test.msg,
+    )
 
 
 @pytest.mark.parametrize(
@@ -733,4 +743,9 @@ def test_divide_mixed(collection, test):
     result = execute_expression_with_insert(
         collection, {"$divide": ["$dividend", test.divisor]}, {"dividend": test.dividend}
     )
-    assertResult(result, expected=test.expected, error_code=test.error_code, msg=test.msg)
+    assertResult(
+        result,
+        expected=[{"result": test.expected}],
+        error_code=test.error_code,
+        msg=test.msg,
+    )

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/utils/utils.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/utils/utils.py
@@ -5,6 +5,7 @@ Provides helper functions for building and executing MongoDB aggregation
 expressions and operators in test scenarios.
 """
 
+from documentdb_tests.framework.assertions import assertResult
 from documentdb_tests.framework.executor import execute_command
 
 
@@ -154,4 +155,25 @@ def execute_expression_with_insert(collection, expression, document):
             ],
             "cursor": {},
         },
+    )
+
+
+def assert_expression_result(result, expected=None, error_code=None, msg=None):
+    """
+    Assert the result of an execute_expression* call.
+
+    Wraps assertResult to handle the {"result": value} projection shape
+    produced by execute_expression and execute_expression_with_insert.
+
+    Args:
+        result: Result from execute_expression or execute_expression_with_insert
+        expected: Expected scalar value (wrapped into [{"result": expected}])
+        error_code: Expected error code (for error cases)
+        msg: Custom assertion message (optional)
+    """
+    assertResult(
+        result,
+        expected=[{"result": expected}] if error_code is None else None,
+        error_code=error_code,
+        msg=msg,
     )

--- a/documentdb_tests/framework/assertions.py
+++ b/documentdb_tests/framework/assertions.py
@@ -157,17 +157,15 @@ def assertResult(
 
     Args:
         result: Result from execute_command
-        expected: Expected result value.
-        error_code: Expected error code (mutually exclusive with expected)
+        expected: Expected result documents (for success cases)
+        error_code: Expected error code (for error cases)
         msg: Custom assertion message (optional)
 
     Usage:
-        assertResult(result, expected=5)  # Success case
+        assertResult(result, expected=[{"_id": 1}])  # Success case
         assertResult(result, error_code=16555)  # Error case
     """
     if error_code is not None:
-        # Error case
         assertFailureCode(result, error_code, msg)
     else:
-        # Success case
-        assertSuccess(result, [{"result": expected}], msg)
+        assertSuccess(result, expected, msg)

--- a/documentdb_tests/framework/test_format_validator.py
+++ b/documentdb_tests/framework/test_format_validator.py
@@ -64,19 +64,13 @@ def validate_test_format(file_path: str) -> list[str]:
                     )
 
             # Check for multiple assertion helper calls
+            # Matches any function call starting with "assert" by convention.
             call_count = sum(
                 1
                 for n in ast.walk(node)
                 if isinstance(n, ast.Call)
                 and isinstance(n.func, ast.Name)
-                and n.func.id
-                in (
-                    "assertSuccess",
-                    "assertFailure",
-                    "assertResult",
-                    "assertFailureCode",
-                    "assertNaN",
-                )
+                and n.func.id.startswith("assert")
             )
 
             if call_count > 1:


### PR DESCRIPTION
The `assertResult` method is currently overfit for operator tests, making it unusable for other tests like aggregation pipelines.

This change moves the fixed `"result: expected"` structure to the call site, to allow the `assertResult` method to be reused more generally. If we decide we want to avoid this at the call site in the future, we can always add an operator-specific wrapper method which delegates to `assertResult` but I haven't included that here since there are relatively few calls to this method at the moment.

Relates to #34 