### PR TITLE
Add pytest_params with per-case mark support

### DIFF
--- a/documentdb_tests/framework/parametrize.py
+++ b/documentdb_tests/framework/parametrize.py
@@ -1,0 +1,15 @@
+"""Pytest parametrize helpers for building test parameter lists."""
+
+from collections.abc import Sequence
+
+import pytest
+
+from documentdb_tests.framework.test_case import BaseTestCase
+
+
+def pytest_params(tests: Sequence[BaseTestCase]):
+    """Build pytest parameters from a sequence of test cases, using each case's id.
+
+    Passes through any pytest marks defined on individual test cases.
+    """
+    return [pytest.param(t, id=t.id, marks=t.marks) for t in tests]

--- a/documentdb_tests/framework/test_case.py
+++ b/documentdb_tests/framework/test_case.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
@@ -19,6 +19,7 @@ class BaseTestCase:
     expected: Any = None
     error_code: Optional[int] = None
     msg: Optional[str] = None
+    marks: tuple = field(default=())
 
     def __post_init__(self):
         if self.msg is None:


### PR DESCRIPTION
This change adds a `pytest_params` helper that builds `pytest.param` lists from typed `BaseTestCase` sequences. It wires up `id` and `marks` automatically.

The change also adds a `marks` field to `BaseTestCase` so individual test cases can carry pytest markers. This enables selective running of specific parametrized cases without marking the entire test function.

Without this helper, every parametrized test would need an inline list comprehension like:

```python
@pytest.mark.parametrize("test_case", [pytest.param(t, id=t.id, marks=t.marks) for t in TESTS])
```

vs:

```python
@pytest.mark.parametrize("test_case", pytest_params(TESTS))
```

And it would be more likely for the parametrization approach to drift, potentially silently dropping marks, etc.

#54 also includes a change similar to this, but without the marks component.