### PR TITLE
Add local pre-commit hooks with CI integration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,20 @@ jobs:
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: pytest -m unit -v

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,34 +5,8 @@ on:
     branches: [main]
 
 jobs:
-  lint:
-    name: Code Style
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install lint tools
-        run: pip install flake8 black isort mypy
-
-      - name: Run flake8
-        run: flake8
-
-      - name: Check black formatting
-        run: black --check .
-
-      - name: Check import sorting
-        run: isort --check-only .
-
-      - name: Run type checking
-        run: mypy documentdb_tests/ --no-site-packages
-
-  unit-tests:
-    name: Unit Tests
+  pre-commit:
+    name: pre-commit checks
     runs-on: ubuntu-latest
 
     steps:
@@ -43,7 +17,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
 
-      - name: Run unit tests
-        run: pytest documentdb_tests/compatibility/result_analyzer/test_analyzer.py -v
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ __marimo__/
 # Test results directory
 .test-results/
 .idea/
+
+# Local pre-commit config (not committed)
+.pre-commit-config.local.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,12 +35,6 @@ repos:
         language: system
         pass_filenames: false
 
-      - id: unit-tests
-        name: unit tests
-        entry: python -m pytest -m unit -v
-        language: system
-        pass_filenames: false
-
       - id: dco
         name: verify DCO
         entry: python hooks/verify_dco.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,4 +46,5 @@ repos:
         entry: python hooks/verify_dco.py
         language: system
         stages: [pre-push]
+        always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  - repo: local
+    hooks:
+      - id: sign-off
+        name: add Signed-off-by
+        entry: python hooks/sign_off.py
+        language: system
+        stages: [prepare-commit-msg]
+        pass_filenames: true
+
+      - id: black
+        name: black
+        entry: python -m black --check
+        language: system
+        types: [python]
+        require_serial: true
+
+      - id: isort
+        name: isort
+        entry: python -m isort --check-only
+        language: system
+        types: [python]
+        require_serial: true
+
+      - id: flake8
+        name: flake8
+        entry: python -m flake8
+        language: system
+        types: [python]
+        require_serial: true
+
+      - id: mypy
+        name: mypy
+        entry: python -m mypy documentdb_tests/ --no-site-packages
+        language: system
+        pass_filenames: false
+
+      - id: unit-tests
+        name: unit tests
+        entry: python -m pytest -m unit -v
+        language: system
+        pass_filenames: false
+
+      - id: dco
+        name: verify DCO
+        entry: python hooks/verify_dco.py
+        language: system
+        stages: [pre-push]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,12 @@ Thank you for your interest in contributing to the DocumentDB Functional Tests! 
    pip install -r requirements-dev.txt
    ```
 
-4. Create a branch for your changes:
+4. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+5. Create a branch for your changes:
    ```bash
    git checkout -b feature/your-feature-name
    ```
@@ -180,23 +185,15 @@ assert actual_doc == expected_doc
 
 ### Before Submitting
 
-Run these commands to ensure code quality:
+Pre-commit hooks run automatically on each commit to check formatting, linting, type checking, and unit tests. You can also run them manually:
 
 ```bash
-# Format code
+# Run all checks
+pre-commit run --all-files
+
+# Format code (auto-fix)
 black .
-
-# Sort imports
 isort .
-
-# Run linter
-flake8
-
-# Type checking (optional but recommended)
-mypy .
-
-# Run tests
-pytest
 ```
 
 ### Code Style
@@ -209,25 +206,32 @@ pytest
 
 ## Testing Your Changes
 
-### Run Tests Locally
+### Unit Tests
+
+Unit tests are marked with `@pytest.mark.unit` and run automatically via pre-commit hooks. To run them directly:
 
 ```bash
-# Run all tests
-pytest
+pytest -m unit -v
+```
 
-# Run specific test file
-pytest tests/find/test_basic_queries.py
+### Functional Tests
 
-# Run specific test
-pytest tests/find/test_basic_queries.py::test_find_all_documents
+Functional tests require a running database instance:
 
-# Run with your changes only
-pytest -m "your_new_tag"
+```bash
+# Run all functional tests
+pytest --connection-string mongodb://localhost:27017 --engine-name documentdb
+
+# Run a specific test file
+pytest documentdb_tests/compatibility/tests/core/query-and-write/commands/find/test_find_basic_queries.py
+
+# Run tests by marker
+pytest -m find
+pytest -m aggregate
+pytest -m smoke
 ```
 
 ### Test Against Multiple Engines
-
-To test against multiple engines, run pytest separately for each engine:
 
 ```bash
 # Test against DocumentDB
@@ -241,15 +245,15 @@ pytest --connection-string mongodb://mongo:27017 --engine-name mongodb
 
 ### Pull Request Process
 
-1. Ensure your code follows the style guidelines
+1. Ensure your code passes all pre-commit checks
 2. Add tests for new functionality
 3. Update documentation if needed
-4. Commit with clear, descriptive messages:
+4. Commit with clear, descriptive messages (a `Signed-off-by` line is added automatically):
    ```bash
    git commit -m "Add tests for $group stage with $avg operator"
    ```
 
-5. Push to your fork:
+5. Push to your fork (DCO sign-off is verified on push):
    ```bash
    git push origin feature/your-feature-name
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thank you for your interest in contributing to the DocumentDB Functional Tests! 
 
 4. Install pre-commit hooks:
    ```bash
-   pre-commit install
+   pre-commit install -t pre-commit -t prepare-commit-msg -t pre-push
    ```
 
 5. Create a branch for your changes:

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -1,5 +1,7 @@
 """Tests for failure extraction and categorization in the analyzer."""
 
+import pytest
+
 from documentdb_tests.compatibility.result_analyzer.analyzer import (
     extract_exception_type,
     extract_failure_tag,
@@ -15,6 +17,7 @@ def _make_test_result(crash_message: str) -> dict:
 # --- extract_failure_tag ---
 
 
+@pytest.mark.unit
 class TestExtractFailureTag:
     def test_result_mismatch(self):
         result = _make_test_result("[RESULT_MISMATCH] Expected [1,2,3] but got [1,2]")
@@ -51,6 +54,7 @@ class TestExtractFailureTag:
 # --- extract_exception_type ---
 
 
+@pytest.mark.unit
 class TestExtractExceptionType:
     def test_simple_exception(self):
         assert extract_exception_type("ConnectionError: refused") == "ConnectionError"
@@ -71,6 +75,7 @@ class TestExtractExceptionType:
 # --- is_infrastructure_error ---
 
 
+@pytest.mark.unit
 class TestIsInfrastructureError:
     def test_connection_error(self):
         result = _make_test_result("ConnectionError: Cannot connect")

--- a/hooks/sign_off.py
+++ b/hooks/sign_off.py
@@ -1,0 +1,22 @@
+"""Ensure the commit message contains a Signed-off-by line."""
+
+import subprocess
+import sys
+
+
+def main():
+    msg_file = sys.argv[1]
+    name = subprocess.check_output(["git", "config", "user.name"], text=True).strip()
+    email = subprocess.check_output(["git", "config", "user.email"], text=True).strip()
+    sob = f"Signed-off-by: {name} <{email}>"
+
+    with open(msg_file, "r") as f:
+        contents = f.read()
+
+    if sob not in contents:
+        with open(msg_file, "a") as f:
+            f.write(f"\n{sob}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/verify_dco.py
+++ b/hooks/verify_dco.py
@@ -1,0 +1,38 @@
+"""Verify that pushed commits authored by the current user have a Signed-off-by line."""
+
+import subprocess
+import sys
+
+
+def main():
+    my_email = subprocess.check_output(["git", "config", "user.email"], text=True).strip()
+
+    for line in sys.stdin:
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        local_oid, remote_oid = parts[1], parts[3]
+
+        null = "0" * 40
+        if local_oid == null:
+            continue
+        rev_range = local_oid if remote_oid == null else f"{remote_oid}..{local_oid}"
+
+        oids = (
+            subprocess.check_output(["git", "rev-list", rev_range], text=True).strip().splitlines()
+        )
+        for oid in oids:
+            author = subprocess.check_output(
+                ["git", "log", "--format=%ae", "-n1", oid], text=True
+            ).strip()
+            if author != my_email:
+                continue
+
+            msg = subprocess.check_output(["git", "log", "--format=%B", "-n1", oid], text=True)
+            if not any(line.startswith("Signed-off-by: ") for line in msg.splitlines()):
+                print(f"ERROR: Commit {oid} missing Signed-off-by.")
+                sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/verify_dco.py
+++ b/hooks/verify_dco.py
@@ -1,5 +1,6 @@
 """Verify that pushed commits authored by the current user have a Signed-off-by line."""
 
+import os
 import subprocess
 import sys
 
@@ -7,31 +8,40 @@ import sys
 def main():
     my_email = subprocess.check_output(["git", "config", "user.email"], text=True).strip()
 
-    for line in sys.stdin:
-        parts = line.split()
-        if len(parts) < 4:
-            continue
-        local_oid, remote_oid = parts[1], parts[3]
+    from_ref = os.environ.get("PRE_COMMIT_FROM_REF") or os.environ.get("PRE_COMMIT_SOURCE")
+    to_ref = os.environ.get("PRE_COMMIT_TO_REF") or os.environ.get("PRE_COMMIT_ORIGIN")
 
-        null = "0" * 40
-        if local_oid == null:
-            continue
-        rev_range = local_oid if remote_oid == null else f"{remote_oid}..{local_oid}"
-
-        oids = (
-            subprocess.check_output(["git", "rev-list", rev_range], text=True).strip().splitlines()
-        )
-        for oid in oids:
-            author = subprocess.check_output(
-                ["git", "log", "--format=%ae", "-n1", oid], text=True
-            ).strip()
-            if author != my_email:
+    if from_ref and to_ref:
+        rev_range = f"{from_ref}..{to_ref}"
+    else:
+        # Fallback: read push info from stdin (native git pre-push)
+        for line in sys.stdin:
+            parts = line.split()
+            if len(parts) < 4:
                 continue
+            local_oid, remote_oid = parts[1], parts[3]
+            null = "0" * 40
+            if local_oid == null:
+                continue
+            rev_range = local_oid if remote_oid == null else f"{remote_oid}..{local_oid}"
+            break
+        else:
+            return
 
-            msg = subprocess.check_output(["git", "log", "--format=%B", "-n1", oid], text=True)
-            if not any(line.startswith("Signed-off-by: ") for line in msg.splitlines()):
-                print(f"ERROR: Commit {oid} missing Signed-off-by.")
-                sys.exit(1)
+    oids = subprocess.check_output(["git", "rev-list", rev_range], text=True).strip().splitlines()
+    for oid in oids:
+        if not oid:
+            continue
+        author = subprocess.check_output(
+            ["git", "log", "--format=%ae", "-n1", oid], text=True
+        ).strip()
+        if author != my_email:
+            continue
+
+        msg = subprocess.check_output(["git", "log", "--format=%B", "-n1", oid], text=True)
+        if not any(line.startswith("Signed-off-by: ") for line in msg.splitlines()):
+            print(f"ERROR: Commit {oid} missing Signed-off-by.")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,13 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-# Already in pytest.ini, keeping this for reference
+markers = [
+    "aggregate: aggregation pipeline tests",
+    "collection_mgmt: collection management tests",
+    "find: find operation tests",
+    "insert: insert operation tests",
+    "slowtest: tests that are slow to run",
+    "smoke: smoke tests",
+    "structures: structure validation tests",
+    "unit: fast unit tests with no external dependencies",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,6 @@ isort>=5.12.0  # Import sorting
 
 # Testing
 pytest-cov>=4.1.0  # Coverage reporting
+
+# Hooks
+pre-commit>=3.0.0  # Git hook management


### PR DESCRIPTION
This change uses [pre-commit](https://pre-commit.com/) to standardize code quality checks across local development and CI.

Previously, various lint checks were running as part of CI, but it was onerous to cover them all properly locally. By using tooling that many contributors will be familiar with, we can make it easy to set up Git hooks which run the correct linting tools. This should help reduce the feedback cycle for contributors.

## Defined hooks

- `black --check`, code formatting, defined in CI before
- `isort --check-only`, import sorting, defined in CI before
- `flake8`, linting, defined in CI before
- `mypy`, type checking, defined in CI before
- `pytest -m unit`, unit tests, defined in CI before
- `sign-off`, automatically adds `Signed-off-by` to commit messages
- `verify dco`, verifies DCO sign-off on push to prevent churn in PRs

All tools run from the local environment via `python -m`, so versions stay in sync with `requirements-dev.txt`.

## Other changes

- Replaced separate lint and unit test jobs with a single `pre-commit run --all-files` step, so CI runs the exact same checks as local commits.
- Registered all custom markers (`aggregate`, `collection_mgmt`, `find`, etc.) to eliminate `PytestUnknownMarkWarning`.
- Added `@pytest.mark.unit` to the project unit tests to allow them to be run by category rather than referencing the specific test.
- `.pre-commit-config.local.yaml` is gitignored, allowing contributors to add their own hooks without affecting the shared config.