### PR TITLE
Add 92 smoke tests, no_parallel marker, and two-phase parallel handling: window operators, query-and-write, query-planning, sessions, administration, diagnostic, security (auth/roles/users)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ pytest -n auto
 pytest -n auto -m smoke --connection-string mongodb://localhost:27017 --engine-name documentdb
 ```
 
+**Two-Phase Execution:**
+Some tests (e.g., `killAllSessions`, `setParameter`, `fsync`) modify global server state and cannot safely run in parallel. These are marked with `no_parallel`. When you use `-n`, the framework automatically:
+1. **Phase 1**: Runs all parallel-safe tests with multiple workers
+2. **Phase 2**: Runs `no_parallel` tests sequentially after Phase 1 completes
+
+This is handled transparently — no extra flags needed.
+
 **Performance Benefits:**
 - Significantly faster test execution with multiple workers
 - Scales with number of available CPU cores
@@ -86,7 +93,7 @@ pytest -n auto -m smoke --connection-string mongodb://localhost:27017 --engine-n
 - Use `-n auto` to automatically detect optimal worker count
 - Parallel execution works best with 4+ workers
 - Each worker runs tests in isolation (separate database/collection)
-- Safe for tests with automatic cleanup (all framework tests are safe)
+- Mark tests with `@pytest.mark.no_parallel` if they modify global server state (kill sessions/ops, change server parameters, drop all users/roles, etc.)
 
 **When to Use:**
 - Large test suites
@@ -229,6 +236,7 @@ tests/
 ### Special Tags
 - `smoke`: Quick smoke tests for feature detection
 - `slow`: Tests that take longer to execute
+- `no_parallel`: Tests that must run sequentially (e.g., tests that kill sessions/ops, modify server config, or drop all users/roles). Automatically deferred to Phase 2 when using `-n`.
 
 ## Writing Tests
 

--- a/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_smoke_window_addToSet.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_smoke_window_addToSet.py
@@ -1,0 +1,39 @@
+"""
+Smoke test for $addToSet window operator.
+
+Tests basic $addToSet window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_addToSet(collection):
+    """Test basic $addToSet window operator behavior."""
+    collection.insert_many([{"_id": 1, "value": 10}, {"_id": 2, "value": 10}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "sortBy": {"_id": 1},
+                        "output": {"uniqueValues": {"$addToSet": "$value"}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "value": 10, "uniqueValues": [10]},
+        {"_id": 2, "value": 10, "uniqueValues": [10]},
+    ]
+    assertSuccess(result, expected, msg="Should support $addToSet window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/avg/test_smoke_window_avg.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/avg/test_smoke_window_avg.py
@@ -1,0 +1,49 @@
+"""
+Smoke test for $avg window operator.
+
+Tests basic $avg window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_avg(collection):
+    """Test basic $avg window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+            {"_id": 4, "partition": "B", "value": 40},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {"avgValue": {"$avg": "$value"}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "avgValue": 20.0},
+        {"_id": 2, "partition": "A", "value": 20, "avgValue": 20.0},
+        {"_id": 3, "partition": "A", "value": 30, "avgValue": 20.0},
+        {"_id": 4, "partition": "B", "value": 40, "avgValue": 40.0},
+    ]
+    assertSuccess(result, expected, msg="Should support $avg window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/bottom/test_smoke_window_bottom.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/bottom/test_smoke_window_bottom.py
@@ -1,0 +1,49 @@
+"""
+Smoke test for $bottom window operator.
+
+Tests basic $bottom window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_bottom(collection):
+    """Test basic $bottom window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "B", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"value": 1},
+                        "output": {
+                            "bottomValue": {"$bottom": {"sortBy": {"value": 1}, "output": "$value"}}
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "bottomValue": 20},
+        {"_id": 2, "partition": "A", "value": 20, "bottomValue": 20},
+        {"_id": 3, "partition": "B", "value": 30, "bottomValue": 30},
+    ]
+    assertSuccess(result, expected, msg="Should support $bottom window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/bottomN/test_smoke_window_bottomN.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/bottomN/test_smoke_window_bottomN.py
@@ -1,0 +1,57 @@
+"""
+Smoke test for $bottomN window operator.
+
+Tests basic $bottomN window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_bottomN(collection):
+    """Test basic $bottomN window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+            {"_id": 4, "partition": "B", "value": 40},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"value": 1},
+                        "output": {
+                            "bottomTwo": {
+                                "$bottomN": {
+                                    "n": 2,
+                                    "sortBy": {"value": 1},
+                                    "output": "$value",
+                                }
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "bottomTwo": [20, 30]},
+        {"_id": 2, "partition": "A", "value": 20, "bottomTwo": [20, 30]},
+        {"_id": 3, "partition": "A", "value": 30, "bottomTwo": [20, 30]},
+        {"_id": 4, "partition": "B", "value": 40, "bottomTwo": [40]},
+    ]
+    assertSuccess(result, expected, msg="Should support $bottomN window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/count/test_smoke_window_count.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/count/test_smoke_window_count.py
@@ -1,0 +1,49 @@
+"""
+Smoke test for $count window operator.
+
+Tests basic $count window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_count(collection):
+    """Test basic $count window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+            {"_id": 4, "partition": "B", "value": 40},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {"runningCount": {"$count": {}}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "runningCount": 3},
+        {"_id": 2, "partition": "A", "value": 20, "runningCount": 3},
+        {"_id": 3, "partition": "A", "value": 30, "runningCount": 3},
+        {"_id": 4, "partition": "B", "value": 40, "runningCount": 1},
+    ]
+    assertSuccess(result, expected, msg="Should support $count window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/covariancePop/test_smoke_window_covariancePop.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/covariancePop/test_smoke_window_covariancePop.py
@@ -1,0 +1,47 @@
+"""
+Smoke test for $covariancePop window operator.
+
+Tests basic $covariancePop window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_covariancePop(collection):
+    """Test basic $covariancePop window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "x": 1, "y": 2},
+            {"_id": 2, "partition": "A", "x": 2, "y": 4},
+            {"_id": 3, "partition": "A", "x": 3, "y": 6},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {"covariance": {"$covariancePop": ["$x", "$y"]}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "x": 1, "y": 2, "covariance": 1.3333333333333333},
+        {"_id": 2, "partition": "A", "x": 2, "y": 4, "covariance": 1.3333333333333333},
+        {"_id": 3, "partition": "A", "x": 3, "y": 6, "covariance": 1.3333333333333333},
+    ]
+    assertSuccess(result, expected, msg="Should support $covariancePop window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/covarianceSamp/test_smoke_window_covarianceSamp.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/covarianceSamp/test_smoke_window_covarianceSamp.py
@@ -1,0 +1,47 @@
+"""
+Smoke test for $covarianceSamp window operator.
+
+Tests basic $covarianceSamp window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_covarianceSamp(collection):
+    """Test basic $covarianceSamp window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "x": 1, "y": 2},
+            {"_id": 2, "partition": "A", "x": 2, "y": 4},
+            {"_id": 3, "partition": "A", "x": 3, "y": 6},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {"covariance": {"$covarianceSamp": ["$x", "$y"]}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "x": 1, "y": 2, "covariance": 2.0},
+        {"_id": 2, "partition": "A", "x": 2, "y": 4, "covariance": 2.0},
+        {"_id": 3, "partition": "A", "x": 3, "y": 6, "covariance": 2.0},
+    ]
+    assertSuccess(result, expected, msg="Should support $covarianceSamp window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/denseRank/test_smoke_window_denseRank.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/denseRank/test_smoke_window_denseRank.py
@@ -1,0 +1,49 @@
+"""
+Smoke test for $denseRank window operator.
+
+Tests basic $denseRank window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_denseRank(collection):
+    """Test basic $denseRank window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "score": 100},
+            {"_id": 2, "partition": "A", "score": 100},
+            {"_id": 3, "partition": "A", "score": 90},
+            {"_id": 4, "partition": "B", "score": 80},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"score": -1},
+                        "output": {"rank": {"$denseRank": {}}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "score": 100, "rank": 1},
+        {"_id": 2, "partition": "A", "score": 100, "rank": 1},
+        {"_id": 3, "partition": "A", "score": 90, "rank": 2},
+        {"_id": 4, "partition": "B", "score": 80, "rank": 1},
+    ]
+    assertSuccess(result, expected, msg="Should support $denseRank window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/derivative/test_smoke_window_derivative.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/derivative/test_smoke_window_derivative.py
@@ -1,0 +1,72 @@
+"""
+Smoke test for $derivative window operator.
+
+Tests basic $derivative window operator functionality.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_derivative(collection):
+    """Test basic $derivative window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "time": datetime(2021, 1, 1, 0, 0, 0), "value": 10},
+            {"_id": 2, "partition": "A", "time": datetime(2021, 1, 1, 0, 0, 1), "value": 20},
+            {"_id": 3, "partition": "A", "time": datetime(2021, 1, 1, 0, 0, 2), "value": 35},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"time": 1},
+                        "output": {
+                            "rate": {
+                                "$derivative": {"input": "$value", "unit": "second"},
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {
+            "_id": 1,
+            "partition": "A",
+            "time": datetime(2021, 1, 1, 0, 0, 0),
+            "value": 10,
+            "rate": None,
+        },
+        {
+            "_id": 2,
+            "partition": "A",
+            "time": datetime(2021, 1, 1, 0, 0, 1),
+            "value": 20,
+            "rate": 10.0,
+        },
+        {
+            "_id": 3,
+            "partition": "A",
+            "time": datetime(2021, 1, 1, 0, 0, 2),
+            "value": 35,
+            "rate": 12.5,
+        },
+    ]
+    assertSuccess(result, expected, msg="Should support $derivative window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/documentNumber/test_smoke_window_documentNumber.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/documentNumber/test_smoke_window_documentNumber.py
@@ -1,0 +1,49 @@
+"""
+Smoke test for $documentNumber window operator.
+
+Tests basic $documentNumber window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_documentNumber(collection):
+    """Test basic $documentNumber window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+            {"_id": 4, "partition": "B", "value": 40},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {"docNumber": {"$documentNumber": {}}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "docNumber": 1},
+        {"_id": 2, "partition": "A", "value": 20, "docNumber": 2},
+        {"_id": 3, "partition": "A", "value": 30, "docNumber": 3},
+        {"_id": 4, "partition": "B", "value": 40, "docNumber": 1},
+    ]
+    assertSuccess(result, expected, msg="Should support $documentNumber window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/expMovingAvg/test_smoke_window_expMovingAvg.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/expMovingAvg/test_smoke_window_expMovingAvg.py
@@ -1,0 +1,47 @@
+"""
+Smoke test for $expMovingAvg window operator.
+
+Tests basic $expMovingAvg window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_expMovingAvg(collection):
+    """Test basic $expMovingAvg window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "stock": "ABC", "price": 10},
+            {"_id": 2, "stock": "ABC", "price": 12},
+            {"_id": 3, "stock": "ABC", "price": 15},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$stock",
+                        "sortBy": {"_id": 1},
+                        "output": {"expMovingAvg": {"$expMovingAvg": {"input": "$price", "N": 2}}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "stock": "ABC", "price": 10, "expMovingAvg": 10.0},
+        {"_id": 2, "stock": "ABC", "price": 12, "expMovingAvg": 11.333333333333334},
+        {"_id": 3, "stock": "ABC", "price": 15, "expMovingAvg": 13.777777777777779},
+    ]
+    assertSuccess(result, expected, msg="Should support $expMovingAvg window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/first/test_smoke_window_first.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/first/test_smoke_window_first.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $first window operator.
+
+Tests basic $first window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_first(collection):
+    """Test basic $first window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "firstValue": {
+                                "$first": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "firstValue": 10},
+        {"_id": 2, "partition": "A", "value": 20, "firstValue": 10},
+        {"_id": 3, "partition": "A", "value": 30, "firstValue": 10},
+    ]
+    assertSuccess(result, expected, msg="Should support $first window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/integral/test_smoke_window_integral.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/integral/test_smoke_window_integral.py
@@ -1,0 +1,53 @@
+"""
+Smoke test for $integral window operator.
+
+Tests basic $integral window operator functionality.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_integral(collection):
+    """Test basic $integral window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "time": datetime(2021, 1, 1, 0, 0, 0), "value": 10},
+            {"_id": 2, "time": datetime(2021, 1, 1, 0, 0, 10), "value": 20},
+            {"_id": 3, "time": datetime(2021, 1, 1, 0, 0, 20), "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "sortBy": {"time": 1},
+                        "output": {
+                            "integral": {
+                                "$integral": {"input": "$value", "unit": "second"},
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "time": datetime(2021, 1, 1, 0, 0, 0), "value": 10, "integral": 0.0},
+        {"_id": 2, "time": datetime(2021, 1, 1, 0, 0, 10), "value": 20, "integral": 150.0},
+        {"_id": 3, "time": datetime(2021, 1, 1, 0, 0, 20), "value": 30, "integral": 400.0},
+    ]
+    assertSuccess(result, expected, msg="Should support $integral window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/last/test_smoke_window_last.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/last/test_smoke_window_last.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $last window operator.
+
+Tests basic $last window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_last(collection):
+    """Test basic $last window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "lastValue": {
+                                "$last": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "lastValue": 10},
+        {"_id": 2, "partition": "A", "value": 20, "lastValue": 20},
+        {"_id": 3, "partition": "A", "value": 30, "lastValue": 30},
+    ]
+    assertSuccess(result, expected, msg="Should support $last window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/linearFill/test_smoke_window_linearFill.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/linearFill/test_smoke_window_linearFill.py
@@ -1,0 +1,46 @@
+"""
+Smoke test for $linearFill window operator.
+
+Tests basic $linearFill window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_linearFill(collection):
+    """Test basic $linearFill window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "time": 1, "value": 10},
+            {"_id": 2, "time": 2, "value": None},
+            {"_id": 3, "time": 3, "value": 20},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "sortBy": {"time": 1},
+                        "output": {"filledValue": {"$linearFill": "$value"}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "time": 1, "value": 10, "filledValue": 10},
+        {"_id": 2, "time": 2, "value": None, "filledValue": 15.0},
+        {"_id": 3, "time": 3, "value": 20, "filledValue": 20},
+    ]
+    assertSuccess(result, expected, msg="Should support $linearFill window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/locf/test_smoke_window_locf.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/locf/test_smoke_window_locf.py
@@ -1,0 +1,48 @@
+"""
+Smoke test for $locf window operator.
+
+Tests basic $locf window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_locf(collection):
+    """Test basic $locf window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "value": 10},
+            {"_id": 2, "value": None},
+            {"_id": 3, "value": None},
+            {"_id": 4, "value": 20},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "sortBy": {"_id": 1},
+                        "output": {"filledValue": {"$locf": "$value"}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "value": 10, "filledValue": 10},
+        {"_id": 2, "value": None, "filledValue": 10},
+        {"_id": 3, "value": None, "filledValue": 10},
+        {"_id": 4, "value": 20, "filledValue": 20},
+    ]
+    assertSuccess(result, expected, msg="Should support $locf window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/max/test_smoke_window_max.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/max/test_smoke_window_max.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $max window operator.
+
+Tests basic $max window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_max(collection):
+    """Test basic $max window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 30},
+            {"_id": 3, "partition": "A", "value": 20},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "maxValue": {
+                                "$max": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "maxValue": 10},
+        {"_id": 2, "partition": "A", "value": 30, "maxValue": 30},
+        {"_id": 3, "partition": "A", "value": 20, "maxValue": 30},
+    ]
+    assertSuccess(result, expected, msg="Should support $max window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/maxN/test_smoke_window_maxN.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/maxN/test_smoke_window_maxN.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $maxN window operator.
+
+Tests basic $maxN window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_maxN(collection):
+    """Test basic $maxN window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 30},
+            {"_id": 3, "partition": "A", "value": 20},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "maxValues": {
+                                "$maxN": {"input": "$value", "n": 2},
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "maxValues": [10]},
+        {"_id": 2, "partition": "A", "value": 30, "maxValues": [30, 10]},
+        {"_id": 3, "partition": "A", "value": 20, "maxValues": [30, 20]},
+    ]
+    assertSuccess(result, expected, msg="Should support $maxN window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/min/test_smoke_window_min.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/min/test_smoke_window_min.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $min window operator.
+
+Tests basic $min window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_min(collection):
+    """Test basic $min window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 30},
+            {"_id": 2, "partition": "A", "value": 10},
+            {"_id": 3, "partition": "A", "value": 20},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "minValue": {
+                                "$min": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 30, "minValue": 30},
+        {"_id": 2, "partition": "A", "value": 10, "minValue": 10},
+        {"_id": 3, "partition": "A", "value": 20, "minValue": 10},
+    ]
+    assertSuccess(result, expected, msg="Should support $min window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/minN/test_smoke_window_minN.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/minN/test_smoke_window_minN.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $minN window operator.
+
+Tests basic $minN window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_minN(collection):
+    """Test basic $minN window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 30},
+            {"_id": 2, "partition": "A", "value": 10},
+            {"_id": 3, "partition": "A", "value": 20},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "minValues": {
+                                "$minN": {"input": "$value", "n": 2},
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 30, "minValues": [30]},
+        {"_id": 2, "partition": "A", "value": 10, "minValues": [10, 30]},
+        {"_id": 3, "partition": "A", "value": 20, "minValues": [10, 20]},
+    ]
+    assertSuccess(result, expected, msg="Should support $minN window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/push/test_smoke_window_push.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/push/test_smoke_window_push.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $push window operator.
+
+Tests basic $push window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_push(collection):
+    """Test basic $push window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "values": {
+                                "$push": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "values": [10]},
+        {"_id": 2, "partition": "A", "value": 20, "values": [10, 20]},
+        {"_id": 3, "partition": "A", "value": 30, "values": [10, 20, 30]},
+    ]
+    assertSuccess(result, expected, msg="Should support $push window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/rank/test_smoke_window_rank.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/rank/test_smoke_window_rank.py
@@ -1,0 +1,47 @@
+"""
+Smoke test for $rank window operator.
+
+Tests basic $rank window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_rank(collection):
+    """Test basic $rank window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "score": 100},
+            {"_id": 2, "partition": "A", "score": 100},
+            {"_id": 3, "partition": "A", "score": 90},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"score": -1},
+                        "output": {"rank": {"$rank": {}}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "score": 100, "rank": 1},
+        {"_id": 2, "partition": "A", "score": 100, "rank": 1},
+        {"_id": 3, "partition": "A", "score": 90, "rank": 3},
+    ]
+    assertSuccess(result, expected, msg="Should support $rank window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/shift/test_smoke_window_shift.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/shift/test_smoke_window_shift.py
@@ -1,0 +1,42 @@
+"""
+Smoke test for $shift window operator.
+
+Tests basic $shift window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_shift(collection):
+    """Test basic $shift window operator behavior."""
+    collection.insert_many(
+        [{"_id": 1, "value": 10}, {"_id": 2, "value": 20}, {"_id": 3, "value": 30}]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "sortBy": {"_id": 1},
+                        "output": {"prevValue": {"$shift": {"output": "$value", "by": -1}}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "value": 10, "prevValue": None},
+        {"_id": 2, "value": 20, "prevValue": 10},
+        {"_id": 3, "value": 30, "prevValue": 20},
+    ]
+    assertSuccess(result, expected, msg="Should support $shift window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/stdDevPop/test_smoke_window_stdDevPop.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/stdDevPop/test_smoke_window_stdDevPop.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $stdDevPop window operator.
+
+Tests basic $stdDevPop window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_stdDevPop(collection):
+    """Test basic $stdDevPop window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "stdDev": {
+                                "$stdDevPop": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "stdDev": 0.0},
+        {"_id": 2, "partition": "A", "value": 20, "stdDev": 5.0},
+        {"_id": 3, "partition": "A", "value": 30, "stdDev": 8.16496580927726},
+    ]
+    assertSuccess(result, expected, msg="Should support $stdDevPop window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/stdDevSamp/test_smoke_window_stdDevSamp.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/stdDevSamp/test_smoke_window_stdDevSamp.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $stdDevSamp window operator.
+
+Tests basic $stdDevSamp window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_stdDevSamp(collection):
+    """Test basic $stdDevSamp window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "stdDev": {
+                                "$stdDevSamp": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "stdDev": None},
+        {"_id": 2, "partition": "A", "value": 20, "stdDev": 7.0710678118654755},
+        {"_id": 3, "partition": "A", "value": 30, "stdDev": 10.0},
+    ]
+    assertSuccess(result, expected, msg="Should support $stdDevSamp window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/sum/test_smoke_window_sum.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/sum/test_smoke_window_sum.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $sum window operator.
+
+Tests basic $sum window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_sum(collection):
+    """Test basic $sum window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "value": 10},
+            {"_id": 2, "partition": "A", "value": 20},
+            {"_id": 3, "partition": "A", "value": 30},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "runningSum": {
+                                "$sum": "$value",
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "runningSum": 10},
+        {"_id": 2, "partition": "A", "value": 20, "runningSum": 30},
+        {"_id": 3, "partition": "A", "value": 30, "runningSum": 60},
+    ]
+    assertSuccess(result, expected, msg="Should support $sum window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/top/test_smoke_window_top.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/top/test_smoke_window_top.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for $top window operator.
+
+Tests basic $top window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_top(collection):
+    """Test basic $top window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "score": 90, "name": "Alice"},
+            {"_id": 2, "partition": "A", "score": 100, "name": "Bob"},
+            {"_id": 3, "partition": "A", "score": 85, "name": "Charlie"},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "topScore": {
+                                "$top": {"sortBy": {"score": -1}, "output": "$name"},
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "score": 90, "name": "Alice", "topScore": "Alice"},
+        {"_id": 2, "partition": "A", "score": 100, "name": "Bob", "topScore": "Bob"},
+        {"_id": 3, "partition": "A", "score": 85, "name": "Charlie", "topScore": "Bob"},
+    ]
+    assertSuccess(result, expected, msg="Should support $top window operator")

--- a/documentdb_tests/compatibility/tests/core/operator/window/topN/test_smoke_window_topN.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/topN/test_smoke_window_topN.py
@@ -1,0 +1,68 @@
+"""
+Smoke test for $topN window operator.
+
+Tests basic $topN window operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_window_topN(collection):
+    """Test basic $topN window operator behavior."""
+    collection.insert_many(
+        [
+            {"_id": 1, "partition": "A", "score": 90, "name": "Alice"},
+            {"_id": 2, "partition": "A", "score": 100, "name": "Bob"},
+            {"_id": 3, "partition": "A", "score": 85, "name": "Charlie"},
+        ]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "topScores": {
+                                "$topN": {
+                                    "sortBy": {"score": -1},
+                                    "output": "$name",
+                                    "n": 2,
+                                },
+                                "window": {"documents": ["unbounded", "current"]},
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [
+        {"_id": 1, "partition": "A", "score": 90, "name": "Alice", "topScores": ["Alice"]},
+        {
+            "_id": 2,
+            "partition": "A",
+            "score": 100,
+            "name": "Bob",
+            "topScores": ["Bob", "Alice"],
+        },
+        {
+            "_id": 3,
+            "partition": "A",
+            "score": 85,
+            "name": "Charlie",
+            "topScores": ["Bob", "Alice"],
+        },
+    ]
+    assertSuccess(result, expected, msg="Should support $topN window operator")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/commands/bulkWrite/test_smoke_bulkWrite.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/commands/bulkWrite/test_smoke_bulkWrite.py
@@ -1,0 +1,30 @@
+"""
+Smoke test for bulkWrite command.
+
+Tests basic bulkWrite command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_bulkWrite(collection):
+    """Test basic bulkWrite command behavior."""
+    result = execute_admin_command(
+        collection,
+        {
+            "bulkWrite": 1,
+            "ops": [
+                {"insert": 0, "document": {"_id": 1, "name": "Alice"}},
+                {"insert": 0, "document": {"_id": 2, "name": "Bob"}},
+            ],
+            "nsInfo": [{"ns": f"{collection.database.name}.{collection.name}"}],
+        },
+    )
+
+    expected = {"ok": 1.0, "nInserted": 2}
+    assertSuccessPartial(result, expected, msg="Should support bulkWrite command")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/commands/delete/test_smoke_delete.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/commands/delete/test_smoke_delete.py
@@ -1,0 +1,27 @@
+"""
+Smoke test for delete command.
+
+Tests basic delete command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_delete(collection):
+    """Test basic delete command behavior."""
+    collection.insert_many(
+        [{"_id": 1, "name": "Alice"}, {"_id": 2, "name": "Bob"}, {"_id": 3, "name": "Charlie"}]
+    )
+
+    result = execute_command(
+        collection,
+        {"delete": collection.name, "deletes": [{"q": {"_id": 1}, "limit": 1}]},
+    )
+
+    expected = {"ok": 1.0, "n": 1}
+    assertSuccessPartial(result, expected, msg="Should support delete command")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/commands/find/test_smoke_find.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/commands/find/test_smoke_find.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for find command.
+
+Tests basic find command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_find(collection):
+    """Test basic find command behavior."""
+    collection.insert_many([{"_id": 1, "name": "Alice"}, {"_id": 2, "name": "Bob"}])
+
+    result = execute_command(collection, {"find": collection.name})
+
+    expected = [{"_id": 1, "name": "Alice"}, {"_id": 2, "name": "Bob"}]
+    assertSuccess(result, expected, msg="Should support find command")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/commands/findAndModify/test_smoke_findAndModify.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/commands/findAndModify/test_smoke_findAndModify.py
@@ -1,0 +1,30 @@
+"""
+Smoke test for findAndModify command.
+
+Tests basic findAndModify command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_findAndModify(collection):
+    """Test basic findAndModify command behavior."""
+    collection.insert_one({"_id": 1, "name": "Alice", "count": 10})
+
+    result = execute_command(
+        collection,
+        {
+            "findAndModify": collection.name,
+            "query": {"_id": 1},
+            "update": {"$inc": {"count": 5}},
+            "new": True,
+        },
+    )
+
+    expected = {"ok": 1.0, "value": {"_id": 1, "name": "Alice", "count": 15}}
+    assertSuccessPartial(result, expected, msg="Should support findAndModify command")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/commands/insert/test_smoke_insert.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/commands/insert/test_smoke_insert.py
@@ -1,0 +1,26 @@
+"""
+Smoke test for insert command.
+
+Tests basic insert command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_insert(collection):
+    """Test basic insert command behavior."""
+    result = execute_command(
+        collection,
+        {
+            "insert": collection.name,
+            "documents": [{"_id": 1, "name": "Alice"}, {"_id": 2, "name": "Bob"}],
+        },
+    )
+
+    expected = {"ok": 1.0, "n": 2}
+    assertSuccessPartial(result, expected, msg="Should support insert command")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/commands/update/test_smoke_update.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/commands/update/test_smoke_update.py
@@ -1,0 +1,28 @@
+"""
+Smoke test for update command.
+
+Tests basic update command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_update(collection):
+    """Test basic update command behavior."""
+    collection.insert_one({"_id": 1, "name": "Alice", "count": 10})
+
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"name": "Bob"}}}],
+        },
+    )
+
+    expected = {"ok": 1.0, "n": 1, "nModified": 1}
+    assertSuccessPartial(result, expected, msg="Should support update command")

--- a/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheClear/test_smoke_planCacheClear.py
+++ b/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheClear/test_smoke_planCacheClear.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for planCacheClear command.
+
+Tests basic planCacheClear command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_planCacheClear(collection):
+    """Test basic planCacheClear command behavior."""
+    result = execute_command(collection, {"planCacheClear": collection.name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support planCacheClear command")

--- a/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheClearFilters/test_smoke_planCacheClearFilters.py
+++ b/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheClearFilters/test_smoke_planCacheClearFilters.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for planCacheClearFilters command.
+
+Tests basic planCacheClearFilters command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_planCacheClearFilters(collection):
+    """Test basic planCacheClearFilters command behavior."""
+    result = execute_command(collection, {"planCacheClearFilters": collection.name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support planCacheClearFilters command")

--- a/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheListFilters/test_smoke_planCacheListFilters.py
+++ b/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheListFilters/test_smoke_planCacheListFilters.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for planCacheListFilters command.
+
+Tests basic planCacheListFilters command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_planCacheListFilters(collection):
+    """Test basic planCacheListFilters command behavior."""
+    result = execute_command(collection, {"planCacheListFilters": collection.name})
+
+    expected = {"filters": [], "ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support planCacheListFilters command")

--- a/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheSetFilter/test_smoke_planCacheSetFilter.py
+++ b/documentdb_tests/compatibility/tests/core/query-planning/commands/planCacheSetFilter/test_smoke_planCacheSetFilter.py
@@ -1,0 +1,25 @@
+"""
+Smoke test for planCacheSetFilter command.
+
+Tests basic planCacheSetFilter command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_planCacheSetFilter(collection):
+    """Test basic planCacheSetFilter command behavior."""
+    collection.insert_one({"_id": 1, "name": "Alice"})
+
+    result = execute_command(
+        collection,
+        {"planCacheSetFilter": collection.name, "query": {"_id": 1}, "indexes": [{"_id": 1}]},
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support planCacheSetFilter command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/endSessions/test_smoke_endSessions.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/endSessions/test_smoke_endSessions.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for endSessions command.
+
+Tests basic endSessions command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_endSessions(collection):
+    """Test basic endSessions command behavior."""
+    result = execute_command(collection, {"endSessions": []})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support endSessions command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/killAllSessions/test_smoke_killAllSessions.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/killAllSessions/test_smoke_killAllSessions.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for killAllSessions command.
+
+Tests basic killAllSessions command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_killAllSessions(collection):
+    """Test basic killAllSessions command behavior."""
+    result = execute_command(collection, {"killAllSessions": []})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support killAllSessions command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/killAllSessionsByPattern/test_smoke_killAllSessionsByPattern.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/killAllSessionsByPattern/test_smoke_killAllSessionsByPattern.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for killAllSessionsByPattern command.
+
+Tests basic killAllSessionsByPattern command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_killAllSessionsByPattern(collection):
+    """Test basic killAllSessionsByPattern command behavior."""
+    result = execute_command(collection, {"killAllSessionsByPattern": []})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support killAllSessionsByPattern command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/killSessions/test_smoke_killSessions.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/killSessions/test_smoke_killSessions.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for killSessions command.
+
+Tests basic killSessions command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_killSessions(collection):
+    """Test basic killSessions command behavior."""
+    result = execute_command(collection, {"killSessions": []})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support killSessions command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/refreshSessions/test_smoke_refreshSessions.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/refreshSessions/test_smoke_refreshSessions.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for refreshSessions command.
+
+Tests basic refreshSessions command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_refreshSessions(collection):
+    """Test basic refreshSessions command behavior."""
+    result = execute_command(collection, {"refreshSessions": []})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support refreshSessions command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/autoCompact/test_smoke_autoCompact.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/autoCompact/test_smoke_autoCompact.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for autoCompact command.
+
+Tests basic autoCompact functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_autoCompact(collection):
+    """Test basic autoCompact behavior."""
+    result = execute_admin_command(collection, {"autoCompact": True})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support autoCompact command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/currentOp/test_smoke_currentOp.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/currentOp/test_smoke_currentOp.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for currentOp command.
+
+Tests basic currentOp functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_currentOp(collection):
+    """Test basic currentOp behavior."""
+    result = execute_admin_command(collection, {"currentOp": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support currentOp command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/dropConnections/test_smoke_dropConnections.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/dropConnections/test_smoke_dropConnections.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for dropConnections command.
+
+Tests basic dropConnections functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_dropConnections(collection):
+    """Test basic dropConnections behavior."""
+    result = execute_admin_command(collection, {"dropConnections": 1, "hostAndPort": []})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dropConnections command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/filemd5/test_smoke_filemd5.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/filemd5/test_smoke_filemd5.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for filemd5 command.
+
+Tests basic filemd5 functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_filemd5(collection):
+    """Test basic filemd5 behavior."""
+    chunks = collection.database["fs.chunks"]
+    chunks.create_index([("files_id", 1), ("n", 1)])
+    chunks.insert_one({"_id": 1, "files_id": 1, "n": 0, "data": b"test"})
+
+    result = execute_command(collection, {"filemd5": 1, "root": "fs"})
+
+    expected = {"ok": 1.0, "numChunks": 1}
+    assertSuccessPartial(result, expected, msg="Should support filemd5 command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/fsync/test_smoke_fsync.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/fsync/test_smoke_fsync.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for fsync command.
+
+Tests basic fsync functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_fsync(collection):
+    """Test basic fsync behavior."""
+    result = execute_admin_command(collection, {"fsync": 1})
+
+    expected = {"ok": 1.0, "numFiles": 1}
+    assertSuccessPartial(result, expected, msg="Should support fsync command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/getClusterParameter/test_smoke_getClusterParameter.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/getClusterParameter/test_smoke_getClusterParameter.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for getClusterParameter command.
+
+Tests basic getClusterParameter functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_getClusterParameter(collection):
+    """Test basic getClusterParameter behavior."""
+    result = execute_admin_command(collection, {"getClusterParameter": "*"})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support getClusterParameter command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/getParameter/test_smoke_getParameter.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/getParameter/test_smoke_getParameter.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for getParameter command.
+
+Tests basic getParameter functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_getParameter(collection):
+    """Test basic getParameter behavior."""
+    result = execute_admin_command(collection, {"getParameter": "*"})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support getParameter command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/killOp/test_smoke_killOp.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/killOp/test_smoke_killOp.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for killOp command.
+
+Tests basic killOp functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_killOp(collection):
+    """Test basic killOp behavior."""
+    result = execute_admin_command(collection, {"killOp": 1, "op": 999999999})
+
+    expected = {"ok": 1.0, "info": "attempting to kill op"}
+    assertSuccessPartial(result, expected, msg="Should support killOp command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/logRotate/test_smoke_logRotate.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/logRotate/test_smoke_logRotate.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for logRotate command.
+
+Tests basic logRotate functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_logRotate(collection):
+    """Test basic logRotate behavior."""
+    result = execute_admin_command(collection, {"logRotate": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support logRotate command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/rotateCertificates/test_smoke_rotateCertificates.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/rotateCertificates/test_smoke_rotateCertificates.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for rotateCertificates command.
+
+Tests basic rotateCertificates functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_rotateCertificates(collection):
+    """Test basic rotateCertificates behavior."""
+    result = execute_admin_command(collection, {"rotateCertificates": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support rotateCertificates command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/setClusterParameter/test_smoke_setClusterParameter.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/setClusterParameter/test_smoke_setClusterParameter.py
@@ -1,0 +1,47 @@
+"""
+Smoke test for setClusterParameter command.
+
+Tests basic setClusterParameter functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_setClusterParameter(collection):
+    """Test basic setClusterParameter behavior."""
+    get_result = execute_admin_command(collection, {"getClusterParameter": "changeStreamOptions"})
+
+    original_seconds = 3600
+    if not isinstance(get_result, Exception) and "clusterParameters" in get_result:
+        params = get_result.get("clusterParameters", [])
+        if params:
+            original_seconds = params[0].get("preAndPostImages", {}).get("expireAfterSeconds", 3600)
+
+    new_seconds = 7200 if original_seconds != 7200 else 3600
+    result = execute_admin_command(
+        collection,
+        {
+            "setClusterParameter": {
+                "changeStreamOptions": {"preAndPostImages": {"expireAfterSeconds": new_seconds}}
+            }
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support setClusterParameter command")
+
+    execute_admin_command(
+        collection,
+        {
+            "setClusterParameter": {
+                "changeStreamOptions": {
+                    "preAndPostImages": {"expireAfterSeconds": original_seconds}
+                }
+            }
+        },
+    )

--- a/documentdb_tests/compatibility/tests/system/administration/commands/setFeatureCompatibilityVersion/test_smoke_setFeatureCompatibilityVersion.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/setFeatureCompatibilityVersion/test_smoke_setFeatureCompatibilityVersion.py
@@ -1,0 +1,41 @@
+"""
+Smoke test for setFeatureCompatibilityVersion command.
+
+Tests basic setFeatureCompatibilityVersion functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_setFeatureCompatibilityVersion(collection):
+    """Test basic setFeatureCompatibilityVersion behavior."""
+    get_result = execute_admin_command(
+        collection, {"getParameter": 1, "featureCompatibilityVersion": 1}
+    )
+
+    original_fcv = "8.2"
+    if not isinstance(get_result, Exception):
+        fcv_data = get_result.get("featureCompatibilityVersion", {})
+        if isinstance(fcv_data, dict):
+            original_fcv = fcv_data.get("version", "8.2")
+        else:
+            original_fcv = str(fcv_data)
+
+    new_fcv = "8.2" if original_fcv != "8.2" else "8.0"
+    result = execute_admin_command(
+        collection, {"setFeatureCompatibilityVersion": new_fcv, "confirm": True}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(
+        result, expected, msg="Should support setFeatureCompatibilityVersion command"
+    )
+
+    execute_admin_command(
+        collection, {"setFeatureCompatibilityVersion": original_fcv, "confirm": True}
+    )

--- a/documentdb_tests/compatibility/tests/system/administration/commands/setParameter/test_smoke_setParameter.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/setParameter/test_smoke_setParameter.py
@@ -1,0 +1,25 @@
+"""
+Smoke test for setParameter command.
+
+Tests basic setParameter functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_setParameter(collection):
+    """Test basic setParameter behavior."""
+    get_result = execute_admin_command(collection, {"getParameter": 1, "logLevel": 1})
+    original_value = get_result.get("logLevel", 0) if not isinstance(get_result, Exception) else 0
+
+    result = execute_admin_command(collection, {"setParameter": 1, "logLevel": 0})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support setParameter command")
+
+    execute_admin_command(collection, {"setParameter": 1, "logLevel": original_value})

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/buildInfo/test_smoke_buildInfo.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/buildInfo/test_smoke_buildInfo.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for buildInfo command.
+
+Tests basic buildInfo command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_buildInfo(collection):
+    """Test basic buildInfo command behavior."""
+    result = execute_admin_command(collection, {"buildInfo": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support buildInfo command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/collStats/test_smoke_command_collStats.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/collStats/test_smoke_command_collStats.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for collStats command.
+
+Tests basic collStats command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_command_collStats(collection):
+    """Test basic collStats command behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(collection, {"collStats": collection.name})
+
+    expected = {"ok": 1.0, "ns": f"{collection.database.name}.{collection.name}"}
+    assertSuccessPartial(result, expected, msg="Should support collStats command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/connPoolStats/test_smoke_connPoolStats.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/connPoolStats/test_smoke_connPoolStats.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for connPoolStats command.
+
+Tests basic connPoolStats command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_connPoolStats(collection):
+    """Test basic connPoolStats command behavior."""
+    result = execute_admin_command(collection, {"connPoolStats": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support connPoolStats command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/connectionStatus/test_smoke_connectionStatus.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/connectionStatus/test_smoke_connectionStatus.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for connectionStatus command.
+
+Tests basic connectionStatus command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_connectionStatus(collection):
+    """Test basic connectionStatus command behavior."""
+    result = execute_admin_command(collection, {"connectionStatus": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support connectionStatus command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/dataSize/test_smoke_dataSize.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/dataSize/test_smoke_dataSize.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for dataSize command.
+
+Tests basic dataSize command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_dataSize(collection):
+    """Test basic dataSize command behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection, {"dataSize": f"{collection.database.name}.{collection.name}"}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dataSize command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/dbHash/test_smoke_dbHash.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/dbHash/test_smoke_dbHash.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for dbHash command.
+
+Tests basic dbHash command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_dbHash(collection):
+    """Test basic dbHash command behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(collection, {"dbHash": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dbHash command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/dbStats/test_smoke_dbStats.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/dbStats/test_smoke_dbStats.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for dbStats command.
+
+Tests basic dbStats command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_dbStats(collection):
+    """Test basic dbStats command behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(collection, {"dbStats": 1})
+
+    expected = {"ok": 1.0, "db": collection.database.name}
+    assertSuccessPartial(result, expected, msg="Should support dbStats command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/explain/test_smoke_explain.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/explain/test_smoke_explain.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for explain command.
+
+Tests basic explain command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_explain(collection):
+    """Test basic explain command behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(collection, {"explain": {"find": collection.name, "filter": {"x": 1}}})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support explain command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/getCmdLineOpts/test_smoke_getCmdLineOpts.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/getCmdLineOpts/test_smoke_getCmdLineOpts.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for getCmdLineOpts command.
+
+Tests basic getCmdLineOpts command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_getCmdLineOpts(collection):
+    """Test basic getCmdLineOpts command behavior."""
+    result = execute_admin_command(collection, {"getCmdLineOpts": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support getCmdLineOpts command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/getLog/test_smoke_getLog.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/getLog/test_smoke_getLog.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for getLog command.
+
+Tests basic getLog command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_getLog(collection):
+    """Test basic getLog command behavior."""
+    result = execute_admin_command(collection, {"getLog": "global"})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support getLog command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/hostInfo/test_smoke_hostInfo.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/hostInfo/test_smoke_hostInfo.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for hostInfo command.
+
+Tests basic hostInfo command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_hostInfo(collection):
+    """Test basic hostInfo command behavior."""
+    result = execute_admin_command(collection, {"hostInfo": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support hostInfo command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/listCommands/test_smoke_listCommands.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/listCommands/test_smoke_listCommands.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for listCommands command.
+
+Tests basic listCommands command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_listCommands(collection):
+    """Test basic listCommands command behavior."""
+    result = execute_admin_command(collection, {"listCommands": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support listCommands command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/ping/test_smoke_ping.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/ping/test_smoke_ping.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for ping command.
+
+Tests basic ping command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_ping(collection):
+    """Test basic ping command behavior."""
+    result = execute_admin_command(collection, {"ping": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support ping command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/profile/test_smoke_profile.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/profile/test_smoke_profile.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for profile command.
+
+Tests basic profile command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_profile(collection):
+    """Test basic profile command behavior."""
+    result = execute_command(collection, {"profile": 0})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support profile command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/serverStatus/test_smoke_serverStatus.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/serverStatus/test_smoke_serverStatus.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for serverStatus command.
+
+Tests basic serverStatus command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_serverStatus(collection):
+    """Test basic serverStatus command behavior."""
+    result = execute_admin_command(collection, {"serverStatus": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support serverStatus command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/top/test_smoke_top.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/top/test_smoke_top.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for top command.
+
+Tests basic top command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_top(collection):
+    """Test basic top command behavior."""
+    result = execute_admin_command(collection, {"top": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support top command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/validate/test_smoke_validate.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/validate/test_smoke_validate.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for validate command.
+
+Tests basic validate command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_validate(collection):
+    """Test basic validate command behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(collection, {"validate": collection.name})
+
+    expected = {"ok": 1.0, "ns": f"{collection.database.name}.{collection.name}"}
+    assertSuccessPartial(result, expected, msg="Should support validate command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/whatsmyuri/test_smoke_whatsmyuri.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/whatsmyuri/test_smoke_whatsmyuri.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for whatsmyuri command.
+
+Tests basic whatsmyuri command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_whatsmyuri(collection):
+    """Test basic whatsmyuri command behavior."""
+    result = execute_admin_command(collection, {"whatsmyuri": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support whatsmyuri command")

--- a/documentdb_tests/compatibility/tests/system/security/authentication/commands/logout/test_smoke_logout.py
+++ b/documentdb_tests/compatibility/tests/system/security/authentication/commands/logout/test_smoke_logout.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for logout command.
+
+Tests basic logout functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_logout(collection):
+    """Test basic logout behavior."""
+    result = execute_command(collection, {"logout": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support logout command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/createRole/test_smoke_createRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/createRole/test_smoke_createRole.py
@@ -1,0 +1,26 @@
+"""
+Smoke test for createRole command.
+
+Tests basic createRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_createRole(collection):
+    """Test basic createRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    result = execute_admin_command(
+        collection, {"createRole": role_name, "privileges": [], "roles": []}
+    )
+
+    execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support createRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/dropAllRolesFromDatabase/test_smoke_dropAllRolesFromDatabase.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/dropAllRolesFromDatabase/test_smoke_dropAllRolesFromDatabase.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for dropAllRolesFromDatabase command.
+
+Tests basic dropAllRolesFromDatabase functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_dropAllRolesFromDatabase(collection):
+    """Test basic dropAllRolesFromDatabase behavior."""
+    result = execute_admin_command(collection, {"dropAllRolesFromDatabase": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dropAllRolesFromDatabase command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/dropRole/test_smoke_dropRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/dropRole/test_smoke_dropRole.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for dropRole command.
+
+Tests basic dropRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_dropRole(collection):
+    """Test basic dropRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    execute_admin_command(collection, {"createRole": role_name, "privileges": [], "roles": []})
+
+    result = execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dropRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/grantPrivilegesToRole/test_smoke_grantPrivilegesToRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/grantPrivilegesToRole/test_smoke_grantPrivilegesToRole.py
@@ -1,0 +1,32 @@
+"""
+Smoke test for grantPrivilegesToRole command.
+
+Tests basic grantPrivilegesToRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_grantPrivilegesToRole(collection):
+    """Test basic grantPrivilegesToRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    execute_admin_command(collection, {"createRole": role_name, "privileges": [], "roles": []})
+
+    result = execute_admin_command(
+        collection,
+        {
+            "grantPrivilegesToRole": role_name,
+            "privileges": [{"resource": {"db": "test", "collection": ""}, "actions": ["find"]}],
+        },
+    )
+
+    execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support grantPrivilegesToRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/grantRolesToRole/test_smoke_grantRolesToRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/grantRolesToRole/test_smoke_grantRolesToRole.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for grantRolesToRole command.
+
+Tests basic grantRolesToRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_grantRolesToRole(collection):
+    """Test basic grantRolesToRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    execute_admin_command(collection, {"createRole": role_name, "privileges": [], "roles": []})
+
+    result = execute_admin_command(
+        collection,
+        {"grantRolesToRole": role_name, "roles": [{"role": "read", "db": "test"}]},
+    )
+
+    execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support grantRolesToRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/invalidateUserCache/test_smoke_invalidateUserCache.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/invalidateUserCache/test_smoke_invalidateUserCache.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for invalidateUserCache command.
+
+Tests basic invalidateUserCache functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_invalidateUserCache(collection):
+    """Test basic invalidateUserCache behavior."""
+    result = execute_admin_command(collection, {"invalidateUserCache": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support invalidateUserCache command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/revokePrivilegesFromRole/test_smoke_revokePrivilegesFromRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/revokePrivilegesFromRole/test_smoke_revokePrivilegesFromRole.py
@@ -1,0 +1,41 @@
+"""
+Smoke test for revokePrivilegesFromRole command.
+
+Tests basic revokePrivilegesFromRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_revokePrivilegesFromRole(collection):
+    """Test basic revokePrivilegesFromRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    execute_admin_command(
+        collection,
+        {
+            "createRole": role_name,
+            "privileges": [
+                {"resource": {"db": "test", "collection": ""}, "actions": ["find", "insert"]}
+            ],
+            "roles": [],
+        },
+    )
+
+    result = execute_admin_command(
+        collection,
+        {
+            "revokePrivilegesFromRole": role_name,
+            "privileges": [{"resource": {"db": "test", "collection": ""}, "actions": ["insert"]}],
+        },
+    )
+
+    execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support revokePrivilegesFromRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/revokeRolesFromRole/test_smoke_revokeRolesFromRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/revokeRolesFromRole/test_smoke_revokeRolesFromRole.py
@@ -1,0 +1,32 @@
+"""
+Smoke test for revokeRolesFromRole command.
+
+Tests basic revokeRolesFromRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_revokeRolesFromRole(collection):
+    """Test basic revokeRolesFromRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    execute_admin_command(
+        collection,
+        {"createRole": role_name, "privileges": [], "roles": [{"role": "read", "db": "test"}]},
+    )
+
+    result = execute_admin_command(
+        collection,
+        {"revokeRolesFromRole": role_name, "roles": [{"role": "read", "db": "test"}]},
+    )
+
+    execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support revokeRolesFromRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/rolesInfo/test_smoke_rolesInfo.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/rolesInfo/test_smoke_rolesInfo.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for rolesInfo command.
+
+Tests basic rolesInfo functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_rolesInfo(collection):
+    """Test basic rolesInfo behavior."""
+    result = execute_admin_command(collection, {"rolesInfo": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support rolesInfo command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/updateRole/test_smoke_updateRole.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/role/commands/updateRole/test_smoke_updateRole.py
@@ -1,0 +1,33 @@
+"""
+Smoke test for updateRole command.
+
+Tests basic updateRole functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_updateRole(collection):
+    """Test basic updateRole behavior."""
+    role_name = f"{collection.name}_test_role"
+
+    execute_admin_command(collection, {"createRole": role_name, "privileges": [], "roles": []})
+
+    result = execute_admin_command(
+        collection,
+        {
+            "updateRole": role_name,
+            "privileges": [{"resource": {"db": "test", "collection": ""}, "actions": ["find"]}],
+            "roles": [],
+        },
+    )
+
+    execute_admin_command(collection, {"dropRole": role_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support updateRole command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/createUser/test_smoke_createUser.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/createUser/test_smoke_createUser.py
@@ -1,0 +1,26 @@
+"""
+Smoke test for createUser command.
+
+Tests basic createUser functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_createUser(collection):
+    """Test basic createUser behavior."""
+    user_name = f"{collection.name}_test_user"
+
+    result = execute_admin_command(
+        collection, {"createUser": user_name, "pwd": "testPassword", "roles": []}
+    )
+
+    execute_admin_command(collection, {"dropUser": user_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support createUser command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/dropAllUsersFromDatabase/test_smoke_dropAllUsersFromDatabase.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/dropAllUsersFromDatabase/test_smoke_dropAllUsersFromDatabase.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for dropAllUsersFromDatabase command.
+
+Tests basic dropAllUsersFromDatabase functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_dropAllUsersFromDatabase(collection):
+    """Test basic dropAllUsersFromDatabase behavior."""
+    result = execute_admin_command(collection, {"dropAllUsersFromDatabase": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dropAllUsersFromDatabase command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/dropUser/test_smoke_dropUser.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/dropUser/test_smoke_dropUser.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for dropUser command.
+
+Tests basic dropUser functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_dropUser(collection):
+    """Test basic dropUser behavior."""
+    user_name = f"{collection.name}_test_user"
+
+    execute_admin_command(collection, {"createUser": user_name, "pwd": "testPassword", "roles": []})
+
+    result = execute_admin_command(collection, {"dropUser": user_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support dropUser command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/grantRolesToUser/test_smoke_grantRolesToUser.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/grantRolesToUser/test_smoke_grantRolesToUser.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for grantRolesToUser command.
+
+Tests basic grantRolesToUser functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_grantRolesToUser(collection):
+    """Test basic grantRolesToUser behavior."""
+    user_name = f"{collection.name}_test_user"
+
+    execute_admin_command(collection, {"createUser": user_name, "pwd": "testPassword", "roles": []})
+
+    result = execute_admin_command(
+        collection,
+        {"grantRolesToUser": user_name, "roles": [{"role": "read", "db": "test"}]},
+    )
+
+    execute_admin_command(collection, {"dropUser": user_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support grantRolesToUser command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/revokeRolesFromUser/test_smoke_revokeRolesFromUser.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/revokeRolesFromUser/test_smoke_revokeRolesFromUser.py
@@ -1,0 +1,36 @@
+"""
+Smoke test for revokeRolesFromUser command.
+
+Tests basic revokeRolesFromUser functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_revokeRolesFromUser(collection):
+    """Test basic revokeRolesFromUser behavior."""
+    user_name = f"{collection.name}_test_user"
+
+    execute_admin_command(
+        collection,
+        {
+            "createUser": user_name,
+            "pwd": "testPassword",
+            "roles": [{"role": "read", "db": "test"}],
+        },
+    )
+
+    result = execute_admin_command(
+        collection,
+        {"revokeRolesFromUser": user_name, "roles": [{"role": "read", "db": "test"}]},
+    )
+
+    execute_admin_command(collection, {"dropUser": user_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support revokeRolesFromUser command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/updateUser/test_smoke_updateUser.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/updateUser/test_smoke_updateUser.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for updateUser command.
+
+Tests basic updateUser functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_updateUser(collection):
+    """Test basic updateUser behavior."""
+    user_name = f"{collection.name}_test_user"
+
+    execute_admin_command(collection, {"createUser": user_name, "pwd": "testPassword", "roles": []})
+
+    result = execute_admin_command(
+        collection,
+        {"updateUser": user_name, "roles": [{"role": "read", "db": "test"}]},
+    )
+
+    execute_admin_command(collection, {"dropUser": user_name})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support updateUser command")

--- a/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/usersInfo/test_smoke_usersInfo.py
+++ b/documentdb_tests/compatibility/tests/system/security/authorization/user/commands/usersInfo/test_smoke_usersInfo.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for usersInfo command.
+
+Tests basic usersInfo functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_usersInfo(collection):
+    """Test basic usersInfo behavior."""
+    result = execute_admin_command(collection, {"usersInfo": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support usersInfo command")

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -102,6 +102,18 @@ def engine_client(request):
     client.close()
 
 
+@pytest.fixture(scope="session")
+def worker_id(request):
+    """
+    Provide worker_id for test isolation, with fallback when xdist is not active.
+
+    Returns xdist's worker_id if available, otherwise 'master'.
+    """
+    if hasattr(request.config, "workerinput"):
+        return request.config.workerinput["workerid"]
+    return "master"
+
+
 @pytest.fixture(scope="function")
 def database_client(engine_client, request, worker_id):
     """
@@ -162,7 +174,26 @@ def collection(database_client, request, worker_id):
 def pytest_collection_modifyitems(session, config, items):
     """
     Combined pytest hook to validate test structure, format, and framework invariants.
+
+    When running with xdist (-n), automatically deselects tests marked with
+    'no_parallel' to prevent interference. Run these separately with:
+        pytest -m no_parallel -p no:xdist
+    Or run them manually with: pytest -m no_parallel -p no:xdist
     """
+    # Deselect no_parallel tests when running under xdist
+    is_xdist = bool(getattr(config.option, "numprocesses", None)) or hasattr(config, "workerinput")
+    if is_xdist:
+        parallel_items = []
+        deselected = []
+        for item in items:
+            if item.get_closest_marker("no_parallel"):
+                deselected.append(item)
+            else:
+                parallel_items.append(item)
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = parallel_items
+
     structure_errors = []
     format_errors = {}
 
@@ -206,3 +237,153 @@ def pytest_collection_modifyitems(session, config, items):
             print("\nSee docs/testing/TEST_FORMAT.md for rules.\n", file=sys.stderr)
 
         pytest.exit("Test validation failed", returncode=1)
+
+
+def _merge_json_reports(phase1_path, phase2_path):
+    """Merge Phase 2 JSON report into Phase 1 report."""
+    import json
+
+    with open(phase1_path) as f:
+        p1 = json.load(f)
+    with open(phase2_path) as f:
+        p2 = json.load(f)
+
+    p1.setdefault("tests", []).extend(p2.get("tests", []))
+    p1["duration"] = p1.get("duration", 0) + p2.get("duration", 0)
+    p1_summary = p1.setdefault("summary", {})
+    p2_summary = p2.get("summary", {})
+    for key in ("passed", "failed", "error", "skipped", "total"):
+        if key in p2_summary:
+            p1_summary[key] = p1_summary.get(key, 0) + p2_summary[key]
+    # Phase 2 runs without xdist, so its collected reflects the true count
+    # before any deselection. Phase 1 under xdist may have a reduced count
+    # due to no_parallel deselection in pytest_collection_modifyitems.
+    p2_collected = p2_summary.get("collected", 0)
+    if p2_collected > 0:
+        p1_summary["collected"] = p2_collected
+    p1_summary.pop("deselected", None)
+
+    with open(phase1_path, "w") as f:
+        json.dump(p1, f, indent=2)
+
+
+def _merge_junit_xml(phase1_path, phase2_path):
+    """Merge Phase 2 JUnit XML into Phase 1 XML."""
+    import xml.etree.ElementTree as ET
+
+    p1_tree = ET.parse(phase1_path)
+    p2_tree = ET.parse(phase2_path)
+    p1_suite = p1_tree.find(".//testsuite")
+    p2_suite = p2_tree.find(".//testsuite")
+    if p1_suite is None or p2_suite is None:
+        return
+
+    for testcase in p2_suite.findall("testcase"):
+        p1_suite.append(testcase)
+
+    for attr in ("tests", "errors", "failures", "skipped"):
+        v1 = int(p1_suite.get(attr, 0))
+        v2 = int(p2_suite.get(attr, 0))
+        p1_suite.set(attr, str(v1 + v2))
+
+    t1 = float(p1_suite.get("time", 0))
+    t2 = float(p2_suite.get("time", 0))
+    p1_suite.set("time", f"{t1 + t2:.3f}")
+
+    p1_tree.write(phase1_path, xml_declaration=True, encoding="utf-8")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    After parallel phase completes, automatically run no_parallel tests sequentially.
+
+    Only triggers on the xdist controller node (not workers, not non-xdist runs).
+    Phase 2 results are merged into Phase 1 report files (JSON and JUnit XML).
+    """
+    config = session.config
+    is_xdist_controller = bool(getattr(config.option, "numprocesses", None)) and not hasattr(
+        config, "workerinput"
+    )
+    if not is_xdist_controller:
+        return
+
+    import os
+    import subprocess
+    import sys
+    import tempfile
+
+    print(
+        f"\n{'='*60}\n" f"Phase 2: Running no_parallel tests sequentially\n" f"{'='*60}\n",
+        flush=True,
+    )
+
+    cmd = [sys.executable, "-m", "pytest", "-p", "no:xdist", "-v"]
+
+    # Combine user's marker expression with no_parallel
+    user_marker = getattr(config.option, "markexpr", "")
+    if user_marker:
+        cmd.extend(["-m", f"no_parallel and ({user_marker})"])
+    else:
+        cmd.extend(["-m", "no_parallel"])
+    cmd.extend(["--connection-string", config.connection_string])
+    cmd.extend(["--engine-name", config.engine_name])
+
+    # Detect Phase 1 report paths and set up Phase 2 temp report files
+    phase1_json = getattr(config.option, "json_report_file", None)
+    phase1_junit = getattr(config.option, "xmlpath", None)
+    phase2_json = None
+    phase2_junit = None
+
+    if phase1_json and os.path.exists(phase1_json):
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=".json", prefix="phase2_")
+        phase2_json = f.name
+        f.close()
+        cmd.extend(["--json-report", f"--json-report-file={phase2_json}"])
+    if phase1_junit and os.path.exists(phase1_junit):
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=".xml", prefix="phase2_")
+        phase2_junit = f.name
+        f.close()
+        cmd.extend([f"--junitxml={phase2_junit}"])
+
+    if config.args:
+        cmd.extend(config.args)
+
+    result = subprocess.call(cmd)
+
+    if result == 5:
+        print("\nℹ️  No no_parallel tests found — Phase 2 skipped")
+    elif result != 0:
+        print(f"\n❌ Phase 2 failed (exit code {result})")
+        session.exitstatus = 1
+    else:
+        print("\n✅ Phase 2 complete — all no_parallel tests passed")
+
+    # Merge Phase 2 reports into Phase 1 reports
+    if phase2_json and os.path.exists(phase2_json):
+        try:
+            _merge_json_reports(phase1_json, phase2_json)
+            print(f"📊 Merged Phase 2 results into {phase1_json}")
+        except Exception as e:
+            print(f"⚠️  Failed to merge JSON reports: {e}", file=sys.stderr)
+        finally:
+            os.unlink(phase2_json)
+
+    if phase2_junit and os.path.exists(phase2_junit):
+        try:
+            _merge_junit_xml(phase1_junit, phase2_junit)
+            print(f"📊 Merged Phase 2 results into {phase1_junit}")
+        except Exception as e:
+            print(f"⚠️  Failed to merge JUnit XML reports: {e}", file=sys.stderr)
+        finally:
+            os.unlink(phase2_junit)
+
+    # Pytest prints its own Phase 1 summary after this hook returns;
+    # add a note so it's not confused with Phase 2 results.
+    print(
+        '\nℹ️  The summary line below ("=== N passed in Xs ===") is Phase 1 (parallel) only. '
+        "See merged report files for combined results.",
+        flush=True,
+    )
+
+    if exitstatus != 0:
+        session.exitstatus = exitstatus

--- a/documentdb_tests/pytest.ini
+++ b/documentdb_tests/pytest.ini
@@ -42,6 +42,7 @@ markers =
     slow: Tests that take longer to execute
     replica: Tests that can only run on a replica
     engine_xfail(engine, reason, raises): expected failure for a specific engine
+    no_parallel: Tests that must run sequentially (not in parallel)
 
 # Timeout for tests (seconds)
 timeout = 300
@@ -49,6 +50,7 @@ timeout = 300
 # Parallel execution settings
 # Use with: pytest -n auto
 # Or: pytest -n 4 (for 4 processes)
+# Tests marked 'no_parallel' are automatically deferred to a sequential phase.
 
 # JSON report options
 # These are command-line options, not config file options


### PR DESCRIPTION
Closes https://github.com/documentdb/functional-tests/issues/60

- 92 smoke tests for: window operators (28), query-and-write commands (6), query planning (4), sessions (5), system administration (13), diagnostics (18), security (18)
- Add no_parallel pytest marker for 14 tests that modify global server state (kill sessions/ops, set parameters, drop all users/roles)
- Add pytest_collection_modifyitems hook to auto-deselect no_parallel tests under xdist
- Add pytest_sessionfinish hook to automatically run no_parallel tests sequentially after parallel phase
- Add worker_id fallback fixture for running without xdist
- Update README with two-phase execution docs