### PR TITLE
Allow doc to be excluded for insertion helper

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/expressions/utils/utils.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/utils/utils.py
@@ -84,7 +84,7 @@ def execute_project_with_insert(collection, document, project):
         ... )
         # Returns result with {"quotient": 3.33...} in firstBatch
     """
-    collection.insert_one(document)
+    collection.insert_one(document or {})
     return execute_command(
         collection,
         {
@@ -145,7 +145,7 @@ def execute_expression_with_insert(collection, expression, document):
         Result from execute_command with structure:
         {"cursor": {"firstBatch": [{"result": <value>}]}}
     """
-    collection.insert_one(document)
+    collection.insert_one(document or {})
     return execute_command(
         collection,
         {


### PR DESCRIPTION
This change allows `execute_expression_with_insert` and `execute_project_with_insert` to accept `None` as the document argument by falling back to an empty dict. This allows tests to optionally exclude the document when using parameterized tests.

For example, some test cases need an inserted document and others don't:

```python
TESTS = [
    ExpressionTestCase("literal", expression={"$sum": [1, 2]}, expected=3),
    ExpressionTestCase("field_ref", expression={"$sum": "$arr"}, doc={"arr": [1, 2, 3]}, expected=6),
]

def test_sum(collection, test_case: ExpressionTestCase):
    result = execute_expression_with_insert(
        collection, test_case.expression, test_case.doc
    )
```

Without this change, the first test case would fail because `insert_one(None)` raises a `TypeError`. Handling the fallback in the helper keeps call sites clean.