### PR TITLE
added tests for $bitsAllSet

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_argument_handling.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_argument_handling.py
@@ -1,0 +1,137 @@
+"""
+Tests for $bitsAllSet valid argument handling.
+
+Validates valid bitmask forms: numeric (integer, Decimal128), BinData, and position list.
+"""
+
+import pytest
+from bson import Binary, Decimal128, Int64
+
+from documentdb_tests.compatibility.tests.core.operator.query.utils.query_test_case import (
+    QueryTestCase,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+from documentdb_tests.framework.test_constants import INT64_MAX
+
+VALID_NUMERIC_BITMASK_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="numeric_bitmask_zero",
+        filter={"a": {"$bitsAllSet": 0}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}, {"_id": 3, "a": -1}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}, {"_id": 3, "a": -1}],
+        msg="Bitmask 0 matches all integer-representable documents",
+    ),
+    QueryTestCase(
+        id="numeric_bitmask_35",
+        filter={"a": {"$bitsAllSet": 35}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 35}, {"_id": 3, "a": 255}],
+        expected=[{"_id": 2, "a": 35}, {"_id": 3, "a": 255}],
+        msg="Bitmask 35 (bits 0,1,5) checks those bits are set",
+    ),
+    QueryTestCase(
+        id="numeric_bitmask_partial_set_fails",
+        filter={"a": {"$bitsAllSet": [1, 3]}},
+        doc=[{"_id": 1, "a": 54}, {"_id": 2, "a": 10}],
+        expected=[{"_id": 2, "a": 10}],
+        msg="a=54 (00110110): bit 1 is SET, bit 3 is CLEAR — partial set does not match",
+    ),
+    QueryTestCase(
+        id="numeric_bitmask_int64_max",
+        filter={"a": {"$bitsAllSet": INT64_MAX}},
+        doc=[{"_id": 1, "a": -1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": -1}],
+        msg="Int64 max as bitmask requires all 63 bits set",
+    ),
+    QueryTestCase(
+        id="numeric_bitmask_decimal128",
+        filter={"a": {"$bitsAllSet": Decimal128("35")}},
+        doc=[{"_id": 1, "a": 35}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 35}],
+        msg="Decimal128 within int64 range accepted as numeric bitmask",
+    ),
+    QueryTestCase(
+        id="numeric_bitmask_decimal128_exponential",
+        filter={"a": {"$bitsAllSet": Decimal128("1E+2")}},
+        doc=[{"_id": 1, "a": 255}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 255}],
+        msg="Decimal128 exponential notation (100) accepted as numeric bitmask",
+    ),
+]
+
+VALID_BINDATA_BITMASK_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="bindata_bitmask_empty",
+        filter={"a": {"$bitsAllSet": Binary(b"")}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}],
+        msg="Empty BinData bitmask matches all",
+    ),
+    QueryTestCase(
+        id="bindata_bitmask_all_ones",
+        filter={"a": {"$bitsAllSet": Binary(b"\xff")}},
+        doc=[{"_id": 1, "a": 255}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 255}],
+        msg="All-ones BinData bitmask",
+    ),
+    QueryTestCase(
+        id="bindata_bitmask_subtype_1",
+        filter={"a": {"$bitsAllSet": Binary(b"\x01", 1)}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 1}],
+        msg="BinData with subtype 1 works as bitmask",
+    ),
+]
+
+VALID_POSITION_LIST_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="position_list_empty",
+        filter={"a": {"$bitsAllSet": []}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}],
+        msg="Empty position list matches all",
+    ),
+    QueryTestCase(
+        id="position_list_single_bit0",
+        filter={"a": {"$bitsAllSet": [0]}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "a": 0}, {"_id": 3, "a": 3}],
+        expected=[{"_id": 1, "a": 1}, {"_id": 3, "a": 3}],
+        msg="Single position [0] checks bit 0 is set",
+    ),
+    QueryTestCase(
+        id="position_list_mid_range_bits",
+        filter={"a": {"$bitsAllSet": [30, 32, 34, 36, 38, 40]}},
+        doc=[
+            {"_id": 1, "a": 0},
+            {"_id": 2, "a": Int64(10737418240)},
+            {"_id": 3, "a": Int64(1465657589760)},
+        ],
+        expected=[{"_id": 3, "a": Int64(1465657589760)}],
+        msg="Mid-range positions spanning byte boundaries 3-5",
+    ),
+    QueryTestCase(
+        id="position_list_decimal128_values",
+        filter={"a": {"$bitsAllSet": [Decimal128("0"), Decimal128("1")]}},
+        doc=[{"_id": 1, "a": 3}, {"_id": 2, "a": 2}],
+        expected=[{"_id": 1, "a": 3}],
+        msg="Decimal128 integer values accepted as positions",
+    ),
+    QueryTestCase(
+        id="position_list_all_64_bits",
+        filter={"a": {"$bitsAllSet": list(range(64))}},
+        doc=[{"_id": 1, "a": -1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": -1}],
+        msg="All 64 positions [0..63] requires all bits set",
+    ),
+]
+
+ALL_TESTS = VALID_NUMERIC_BITMASK_TESTS + VALID_BINDATA_BITMASK_TESTS + VALID_POSITION_LIST_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(ALL_TESTS))
+def test_bitsAllSet_valid_arguments(collection, test):
+    """Test $bitsAllSet with valid bitmask forms (numeric, BinData, position list)."""
+    collection.insert_many(test.doc)
+    result = execute_command(collection, {"find": collection.name, "filter": test.filter})
+    assertSuccess(result, test.expected, ignore_doc_order=True)

--- a/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_cross_type.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_cross_type.py
@@ -1,0 +1,179 @@
+"""
+Tests for $bitsAllSet cross-type behavior.
+
+Validates BinData subtype handling, variable-length BinData with zero extension,
+little-endian byte order for BinData bitmasks, and Decimal128 field values including
+integer-representable, negative two's complement, negative zero, and array-of-Decimal128
+matching.
+"""
+
+import pytest
+from bson import Binary, Decimal128
+
+from documentdb_tests.compatibility.tests.core.operator.query.utils.query_test_case import (
+    QueryTestCase,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+
+BINDATA_SUBTYPE_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="bindata_subtype_0",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Binary(b"\x03")}, {"_id": 2, "a": Binary(b"\x06")}],
+        # driver automatically converts subtype 0 to raw bytes,
+        # so expected is in raw form instead of Binary(b"\x03", 0)
+        expected=[{"_id": 1, "a": b"\x03"}],
+        msg="BinData subtype 128 (user-defined) bit checking works",
+    ),
+    QueryTestCase(
+        id="bindata_subtype_1",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Binary(b"\x03", 1)}, {"_id": 2, "a": Binary(b"\x06", 1)}],
+        expected=[{"_id": 1, "a": Binary(b"\x03", 1)}],
+        msg="BinData subtype 1 (function) same bit checking",
+    ),
+    QueryTestCase(
+        id="bindata_subtype_2_length_prefixed",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Binary(b"\x03", 2)}, {"_id": 2, "a": Binary(b"\x06", 2)}],
+        expected=[{"_id": 1, "a": Binary(b"\x03", 2)}, {"_id": 2, "a": Binary(b"\x06", 2)}],
+        msg="BinData subtype 2 (old binary) has length prefix, checks prefixed data",
+    ),
+    QueryTestCase(
+        id="bindata_subtype_128",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Binary(b"\x03", 128)}, {"_id": 2, "a": Binary(b"\x06", 128)}],
+        expected=[{"_id": 1, "a": Binary(b"\x03", 128)}],
+        msg="BinData subtype 128 (user-defined) bit checking works",
+    ),
+]
+
+VARIABLE_LENGTH_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="bindata_1byte_zero_ext_bit8",
+        filter={"a": {"$bitsAllSet": [8]}},
+        doc=[{"_id": 1, "a": Binary(b"\xff", 128)}],
+        expected=[],
+        msg="1-byte BinData: bit 8 beyond data is zero-extended (not set)",
+    ),
+    QueryTestCase(
+        id="bindata_2byte_bit15_check",
+        filter={"a": {"$bitsAllSet": [15]}},
+        doc=[
+            {"_id": 1, "a": Binary(b"\xff\xff", 128)},
+            {"_id": 2, "a": Binary(b"\xff\x7f", 128)},
+        ],
+        expected=[{"_id": 1, "a": Binary(b"\xff\xff", 128)}],
+        msg="2-byte BinData: bit 15 check",
+    ),
+    QueryTestCase(
+        id="bindata_2byte_zero_ext_bit16",
+        filter={"a": {"$bitsAllSet": [16]}},
+        doc=[{"_id": 1, "a": Binary(b"\xff\xff", 128)}],
+        expected=[],
+        msg="2-byte BinData: bit 16 beyond data is zero-extended (not set)",
+    ),
+    QueryTestCase(
+        id="bindata_20byte_bit159_check",
+        filter={"a": {"$bitsAllSet": [159]}},
+        doc=[
+            {"_id": 1, "a": Binary(b"\xff" * 20, 128)},
+            {"_id": 2, "a": Binary(b"\xff" * 19 + b"\x7f", 128)},
+        ],
+        expected=[{"_id": 1, "a": Binary(b"\xff" * 20, 128)}],
+        msg="20-byte BinData: bit 159 check",
+    ),
+]
+
+LITTLE_ENDIAN_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="bindata_little_endian_byte_order",
+        filter={"a": {"$bitsAllSet": Binary(b"\x00\x20")}},
+        doc=[{"_id": 1, "a": 8192}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 8192}],
+        msg="BinData [0x00, 0x20] little-endian checks bit 13",
+    ),
+    QueryTestCase(
+        id="bindata_little_endian_equiv_position_13",
+        filter={"a": {"$bitsAllSet": [13]}},
+        doc=[{"_id": 1, "a": 8192}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 8192}],
+        msg="Position [13] equivalent to BinData [0x00, 0x20]",
+    ),
+]
+
+DECIMAL128_FIELD_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="bindata_bitmask_on_decimal128_field",
+        filter={"a": {"$bitsAllSet": Binary(b"\x01")}},
+        doc=[{"_id": 1, "a": Decimal128("1")}, {"_id": 2, "a": Decimal128("2")}],
+        expected=[{"_id": 1, "a": Decimal128("1")}],
+        msg="BinData bitmask checks bit 0 on Decimal128 field values",
+    ),
+    QueryTestCase(
+        id="decimal128_integer_bit0_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Decimal128("1")}, {"_id": 2, "a": Decimal128("20")}],
+        expected=[{"_id": 1, "a": Decimal128("1")}],
+        msg="Decimal128 integer value works like int",
+    ),
+    QueryTestCase(
+        id="decimal128_zero_no_bits_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Decimal128("0")}],
+        expected=[],
+        msg="Decimal128 zero has no bits set",
+    ),
+    QueryTestCase(
+        id="decimal128_negative_zero",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Decimal128("-0")}, {"_id": 2, "a": Decimal128("1")}],
+        expected=[{"_id": 2, "a": Decimal128("1")}],
+        msg="Decimal128 negative zero treated as integer 0, no bits set",
+    ),
+    QueryTestCase(
+        id="decimal128_neg1_all_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Decimal128("-1")}, {"_id": 2, "a": Decimal128("0")}],
+        expected=[{"_id": 1, "a": Decimal128("-1")}],
+        msg="Decimal128 -1 has all bits set",
+    ),
+    QueryTestCase(
+        id="decimal128_at_int64_max",
+        filter={"a": {"$bitsAllSet": 0}},
+        doc=[{"_id": 1, "a": Decimal128("9223372036854775807")}],
+        expected=[{"_id": 1, "a": Decimal128("9223372036854775807")}],
+        msg="Decimal128 at INT64_MAX is representable",
+    ),
+    QueryTestCase(
+        id="decimal128_neg2_twos_complement",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Decimal128("-2")}, {"_id": 2, "a": Decimal128("-1")}],
+        expected=[{"_id": 2, "a": Decimal128("-1")}],
+        msg="Decimal128 -2: bit 0 clear in two's complement, -1 has bit 0 set",
+    ),
+    QueryTestCase(
+        id="decimal128_array_any_element",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[
+            {"_id": 1, "a": [Decimal128("1"), Decimal128("20")]},
+            {"_id": 2, "a": [Decimal128("20"), Decimal128("4")]},
+        ],
+        expected=[{"_id": 1, "a": [Decimal128("1"), Decimal128("20")]}],
+        msg="Array of Decimal128 matches if any element satisfies",
+    ),
+]
+
+ALL_TESTS = (
+    BINDATA_SUBTYPE_TESTS + VARIABLE_LENGTH_TESTS + LITTLE_ENDIAN_TESTS + DECIMAL128_FIELD_TESTS
+)
+
+
+@pytest.mark.parametrize("test", pytest_params(ALL_TESTS))
+def test_bitsAllSet_cross_type(collection, test):
+    """Test $bitsAllSet cross-type behavior with BinData and Decimal128."""
+    collection.insert_many(test.doc)
+    result = execute_command(collection, {"find": collection.name, "filter": test.filter})
+    assertSuccess(result, test.expected, ignore_doc_order=True)

--- a/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_data_type_coverage.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_data_type_coverage.py
@@ -1,0 +1,86 @@
+"""
+Tests for $bitsAllSet data type coverage.
+
+Validates matching behavior across valid field types (int32, int64, double, BinData)
+and numeric cross-type equivalence (int32/int64/double/Decimal128).
+"""
+
+import pytest
+from bson import Binary, Decimal128, Int64
+
+from documentdb_tests.compatibility.tests.core.operator.query.utils.query_test_case import (
+    QueryTestCase,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+from documentdb_tests.framework.test_constants import DOUBLE_NEGATIVE_ZERO
+
+VALID_FIELD_TYPE_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="int32_field_bit0_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "a": 20}],
+        expected=[{"_id": 1, "a": 1}],
+        msg="Int32 field with bit 0 set matches",
+    ),
+    QueryTestCase(
+        id="int64_field_bit0_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Int64(1)}, {"_id": 2, "a": Int64(20)}],
+        expected=[{"_id": 1, "a": Int64(1)}],
+        msg="Int64 field with bit 0 set matches",
+    ),
+    QueryTestCase(
+        id="double_field_bit0_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": 1.0}, {"_id": 2, "a": 20.0}],
+        expected=[{"_id": 1, "a": 1.0}],
+        msg="Double (integer-representable) field with bit 0 set matches",
+    ),
+    QueryTestCase(
+        id="bindata_field_bit0_set",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": Binary(b"\x01", 128)}, {"_id": 2, "a": Binary(b"\x06", 128)}],
+        expected=[{"_id": 1, "a": Binary(b"\x01", 128)}],
+        msg="BinData field with bit 0 set matches numeric bitmask",
+    ),
+    QueryTestCase(
+        id="negative_zero_matches",
+        filter={"a": {"$bitsAllSet": 0}},
+        doc=[{"_id": 1, "a": DOUBLE_NEGATIVE_ZERO}, {"_id": 2, "a": 1}],
+        expected=[{"_id": 1, "a": DOUBLE_NEGATIVE_ZERO}, {"_id": 2, "a": 1}],
+        msg="Negative zero treated as integer 0, bitmask 0 matches all int-representable",
+    ),
+]
+
+NUMERIC_EQUIVALENCE_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="numeric_cross_type_equivalence",
+        filter={"a": {"$bitsAllSet": [0, 1]}},
+        doc=[
+            {"_id": 1, "a": 3},
+            {"_id": 2, "a": Int64(3)},
+            {"_id": 3, "a": 3.0},
+            {"_id": 4, "a": Decimal128("3")},
+            {"_id": 5, "a": 20},
+        ],
+        expected=[
+            {"_id": 1, "a": 3},
+            {"_id": 2, "a": Int64(3)},
+            {"_id": 3, "a": 3.0},
+            {"_id": 4, "a": Decimal128("3")},
+        ],
+        msg="Int32, Int64, Double, Decimal128 of same value produce same match result",
+    ),
+]
+
+ALL_TESTS = VALID_FIELD_TYPE_TESTS + NUMERIC_EQUIVALENCE_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(ALL_TESTS))
+def test_bitsAllSet_data_type_coverage(collection, test):
+    """Test $bitsAllSet matching behavior across valid BSON field types."""
+    collection.insert_many(test.doc)
+    result = execute_command(collection, {"find": collection.name, "filter": test.filter})
+    assertSuccess(result, test.expected, ignore_doc_order=True)

--- a/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_field_lookup.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_field_lookup.py
@@ -1,0 +1,116 @@
+"""
+Tests for $bitsAllSet field lookup patterns, cross-type combinations, and algebraic properties.
+
+Validates simple/nested/array field paths, deeply nested paths through arrays of objects,
+cross-type field/bitmask combinations (numeric field with BinData bitmask and vice versa),
+position list order invariance, and three-form equivalence (numeric, position list, BinData).
+"""
+
+import pytest
+from bson import Binary
+
+from documentdb_tests.compatibility.tests.core.operator.query.utils.query_test_case import (
+    QueryTestCase,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+
+FIELD_LOOKUP_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="simple_field_path",
+        filter={"a": {"$bitsAllSet": [0, 1]}},
+        doc=[{"_id": 1, "a": 3}, {"_id": 2, "a": 2}],
+        expected=[{"_id": 1, "a": 3}],
+        msg="Simple field path matches when bits 0,1 are set in 3 (binary 11)",
+    ),
+    QueryTestCase(
+        id="nested_field_dot_notation",
+        filter={"a.b": {"$bitsAllSet": [0, 1]}},
+        doc=[{"_id": 1, "a": {"b": 3}}, {"_id": 2, "a": {"b": 2}}],
+        expected=[{"_id": 1, "a": {"b": 3}}],
+        msg="Nested field path with dot notation",
+    ),
+    QueryTestCase(
+        id="array_field_any_element_match",
+        filter={"a": {"$bitsAllSet": [0, 1]}},
+        doc=[{"_id": 1, "a": [3, 20]}, {"_id": 2, "a": [4, 8]}],
+        expected=[{"_id": 1, "a": [3, 20]}],
+        msg="Array field matches if any element satisfies (3 has bits 0,1 set)",
+    ),
+    QueryTestCase(
+        id="array_index_path",
+        filter={"a.0": {"$bitsAllSet": [0, 1]}},
+        doc=[{"_id": 1, "a": [3, 20]}, {"_id": 2, "a": [2, 3]}],
+        expected=[{"_id": 1, "a": [3, 20]}],
+        msg="Array index path checks element at index 0",
+    ),
+    QueryTestCase(
+        id="deep_nested_path_through_array_of_objects",
+        filter={"a.b.c.d": {"$bitsAllSet": [0, 1]}},
+        doc=[
+            {"_id": 1, "a": {"b": [{"c": {"d": 3}}, {"c": {"d": 2}}]}},
+            {"_id": 2, "a": {"b": [{"c": {"d": 4}}, {"c": {"d": 8}}]}},
+        ],
+        expected=[{"_id": 1, "a": {"b": [{"c": {"d": 3}}, {"c": {"d": 2}}]}}],
+        msg="Deep nested path traverses array of objects at intermediate level",
+    ),
+]
+
+CROSS_TYPE_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="numeric_field_with_bindata_bitmask",
+        filter={"a": {"$bitsAllSet": Binary(b"\x01")}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 1}],
+        msg="Numeric field with BinData bitmask checking bit 0",
+    ),
+    QueryTestCase(
+        id="bindata_field_with_position_list",
+        filter={"a": {"$bitsAllSet": [0]}},
+        doc=[{"_id": 1, "a": Binary(b"\x01", 128)}, {"_id": 2, "a": Binary(b"\x06", 128)}],
+        expected=[{"_id": 1, "a": Binary(b"\x01", 128)}],
+        msg="BinData field with position list bitmask",
+    ),
+    QueryTestCase(
+        id="bindata_field_with_longer_bindata_bitmask",
+        filter={"a": {"$bitsAllSet": Binary(b"\x01\x00\x00")}},
+        doc=[{"_id": 1, "a": Binary(b"\x01", 128)}, {"_id": 2, "a": Binary(b"\x06", 128)}],
+        expected=[{"_id": 1, "a": Binary(b"\x01", 128)}],
+        msg="BinData field with BinData bitmask of different length",
+    ),
+]
+
+ALGEBRAIC_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="position_order_invariance_asc",
+        filter={"a": {"$bitsAllSet": [0, 1, 5]}},
+        doc=[{"_id": 1, "a": 35}, {"_id": 2, "a": 3}, {"_id": 3, "a": 255}],
+        expected=[{"_id": 1, "a": 35}, {"_id": 3, "a": 255}],
+        msg="Position list [0,1,5] ascending order",
+    ),
+    QueryTestCase(
+        id="position_order_invariance_desc",
+        filter={"a": {"$bitsAllSet": [5, 1, 0]}},
+        doc=[{"_id": 1, "a": 35}, {"_id": 2, "a": 3}, {"_id": 3, "a": 255}],
+        expected=[{"_id": 1, "a": 35}, {"_id": 3, "a": 255}],
+        msg="Position list [5,1,0] descending order produces same result",
+    ),
+    QueryTestCase(
+        id="three_form_equivalence_bindata",
+        filter={"a": {"$bitsAllSet": Binary(b"\x23")}},
+        doc=[{"_id": 1, "a": 35}, {"_id": 2, "a": 3}, {"_id": 3, "a": 255}],
+        expected=[{"_id": 1, "a": 35}, {"_id": 3, "a": 255}],
+        msg="BinData 0x23 (bits 0,1,5) equivalent to numeric 35 and position list [0,1,5]",
+    ),
+]
+
+ALL_TESTS = FIELD_LOOKUP_TESTS + CROSS_TYPE_TESTS + ALGEBRAIC_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(ALL_TESTS))
+def test_bitsAllSet_field_lookup(collection, test):
+    """Test $bitsAllSet field lookup, cross-type combinations, and algebraic properties."""
+    collection.insert_many(test.doc)
+    result = execute_command(collection, {"find": collection.name, "filter": test.filter})
+    assertSuccess(result, test.expected, ignore_doc_order=True)

--- a/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_sign_extension.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/bitwise/bitsAllSet/test_bitsAllSet_sign_extension.py
@@ -1,0 +1,182 @@
+"""
+Tests for $bitsAllSet sign extension, edge cases, and boundary values.
+
+Validates two's complement sign extension for negative integers, BinData zero extension,
+identity bitmasks (0, empty list, empty BinData), duplicate positions, large representable
+doubles, and Int32/Int64/Decimal128 boundary values.
+"""
+
+import pytest
+from bson import Binary, Decimal128, Int64
+
+from documentdb_tests.compatibility.tests.core.operator.query.utils.query_test_case import (
+    QueryTestCase,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+from documentdb_tests.framework.test_constants import (
+    INT32_MAX,
+    INT32_MIN,
+    INT64_MAX,
+    INT64_MIN,
+)
+
+SIGN_EXTENSION_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="neg1_all_bits_set",
+        filter={"a": {"$bitsAllSet": [0]}},
+        doc=[{"_id": 1, "a": -1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": -1}],
+        msg="-1 has all bits set, bit 0 is set",
+    ),
+    QueryTestCase(
+        id="negative_sign_extended_high_bit",
+        filter={"a": {"$bitsAllSet": [200]}},
+        doc=[{"_id": 1, "a": -5}, {"_id": 2, "a": 5}],
+        expected=[{"_id": 1, "a": -5}],
+        msg="Negative: bit 200 SET via sign extension; positive: bit 200 NOT set",
+    ),
+    QueryTestCase(
+        id="positive_high_bit_not_set",
+        filter={"a": {"$bitsAllSet": [200]}},
+        doc=[{"_id": 1, "a": 5}],
+        expected=[],
+        msg="Positive number: bits beyond 63 are 0, not set",
+    ),
+    QueryTestCase(
+        id="negative_high_bit_set",
+        filter={"a": {"$bitsAllSet": [200]}},
+        doc=[{"_id": 1, "a": -5}],
+        expected=[{"_id": 1, "a": -5}],
+        msg="Negative number: bits beyond 63 are 1 due to sign extension",
+    ),
+    QueryTestCase(
+        id="neg1_with_bitmask_zero",
+        filter={"a": {"$bitsAllSet": 0}},
+        doc=[{"_id": 1, "a": -1}],
+        expected=[{"_id": 1, "a": -1}],
+        msg="Bitmask 0 means no bits to check, matches even -1",
+    ),
+    QueryTestCase(
+        id="neg2_bit1_set",
+        filter={"a": {"$bitsAllSet": 2}},
+        doc=[{"_id": 1, "a": -2}, {"_id": 2, "a": 1}],
+        expected=[{"_id": 1, "a": -2}],
+        msg="-2 (binary ...11111110) has bit 1 set",
+    ),
+    QueryTestCase(
+        id="int64_min_bit0_not_set",
+        filter={"a": {"$bitsAllSet": [0]}},
+        doc=[{"_id": 1, "a": INT64_MIN}, {"_id": 2, "a": 1}],
+        expected=[{"_id": 2, "a": 1}],
+        msg="INT64_MIN: only bit 63 set, bit 0 is NOT set",
+    ),
+    QueryTestCase(
+        id="int64_min_bit63_set",
+        filter={"a": {"$bitsAllSet": [63]}},
+        doc=[{"_id": 1, "a": INT64_MIN}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": INT64_MIN}],
+        msg="INT64_MIN: bit 63 is set (sign bit)",
+    ),
+]
+
+EDGE_CASE_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="bitmask_zero_skips_non_numeric",
+        filter={"a": {"$bitsAllSet": 0}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}, {"_id": 3, "a": -1}, {"_id": 4, "a": "str"}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}, {"_id": 3, "a": -1}],
+        msg="Bitmask 0 matches all integer-representable, not string",
+    ),
+    QueryTestCase(
+        id="empty_position_list_skips_non_numeric",
+        filter={"a": {"$bitsAllSet": []}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}, {"_id": 3, "a": "str"}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}],
+        msg="Empty position list matches all integer-representable, not string",
+    ),
+    QueryTestCase(
+        id="empty_bindata_skips_non_numeric",
+        filter={"a": {"$bitsAllSet": Binary(b"")}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}, {"_id": 3, "a": "str"}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 2, "a": 255}],
+        msg="Empty BinData matches all integer-representable, not string",
+    ),
+    QueryTestCase(
+        id="large_double_1e18_representable",
+        filter={"a": {"$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": 1e18}, {"_id": 2, "a": 1.0}],
+        expected=[{"_id": 2, "a": 1.0}],
+        msg="1e18 is representable as int64 but bit 0 is not set; 1.0 has bit 0 set",
+    ),
+    QueryTestCase(
+        id="duplicate_positions_ignored",
+        filter={"a": {"$bitsAllSet": [0, 0, 0]}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": 1}],
+        msg="Duplicate positions behave same as deduplicated [0]",
+    ),
+]
+
+BOUNDARY_VALUE_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="int32_max_lower_bits_set",
+        filter={"a": {"$bitsAllSet": [0, 1, 2, 3, 4, 5, 6, 7]}},
+        doc=[{"_id": 1, "a": INT32_MAX}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": INT32_MAX}],
+        msg="INT32_MAX (0x7FFFFFFF) has all lower bits set",
+    ),
+    QueryTestCase(
+        id="int32_min_bit31_set",
+        filter={"a": {"$bitsAllSet": [31]}},
+        doc=[{"_id": 1, "a": INT32_MIN}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": INT32_MIN}],
+        msg="INT32_MIN: bit 31 is set (sign bit in 32-bit representation)",
+    ),
+    QueryTestCase(
+        id="int64_max_with_bitmask_zero",
+        filter={"a": {"$bitsAllSet": 0}},
+        doc=[{"_id": 1, "a": INT64_MAX}],
+        expected=[{"_id": 1, "a": INT64_MAX}],
+        msg="INT64_MAX with bitmask 0 matches",
+    ),
+    QueryTestCase(
+        id="neg1_matches_any_bitmask",
+        filter={"a": {"$bitsAllSet": 255}},
+        doc=[{"_id": 1, "a": -1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": -1}],
+        msg="Field value -1 has all bits set, matches any bitmask",
+    ),
+    QueryTestCase(
+        id="position_0_is_lowest_bit",
+        filter={"a": {"$bitsAllSet": [0]}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "a": 2}],
+        expected=[{"_id": 1, "a": 1}],
+        msg="Position 0 is the lowest bit",
+    ),
+    QueryTestCase(
+        id="position_63_is_highest_bit",
+        filter={"a": {"$bitsAllSet": [63]}},
+        doc=[{"_id": 1, "a": Int64(-1)}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": Int64(-1)}],
+        msg="Position 63 is the highest bit in 64-bit signed integer",
+    ),
+    QueryTestCase(
+        id="decimal128_int64_max_as_bitmask",
+        filter={"a": {"$bitsAllSet": Decimal128("9223372036854775807")}},
+        doc=[{"_id": 1, "a": -1}, {"_id": 2, "a": 0}],
+        expected=[{"_id": 1, "a": -1}],
+        msg="Decimal128 at int64 max boundary accepted as bitmask",
+    ),
+]
+
+ALL_TESTS = SIGN_EXTENSION_TESTS + EDGE_CASE_TESTS + BOUNDARY_VALUE_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(ALL_TESTS))
+def test_bitsAllSet_sign_extension_and_edge_cases(collection, test):
+    """Test $bitsAllSet sign extension, two's complement, edge cases, and boundary values."""
+    collection.insert_many(test.doc)
+    result = execute_command(collection, {"find": collection.name, "filter": test.filter})
+    assertSuccess(result, test.expected, ignore_doc_order=True)

--- a/documentdb_tests/compatibility/tests/core/operator/query/test_query_combination_bitwise_operators.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/test_query_combination_bitwise_operators.py
@@ -1,5 +1,5 @@
 """
-Tests for $bitsAllClear combined with other query operators.
+Tests for $bitsAllClear and $bitsAllSet combined with other query operators.
 
 Validates combinations with $not, $exists, $elemMatch, $type, $gt, $lt, $gte, $lte,
 $and, $or, and compound bitwise operators across single and multiple fields.
@@ -14,7 +14,7 @@ from documentdb_tests.framework.assertions import assertSuccess
 from documentdb_tests.framework.executor import execute_command
 from documentdb_tests.framework.parametrize import pytest_params
 
-OPERATOR_COMBINATION_TESTS: list[QueryTestCase] = [
+BITSALLCLEAR_COMBINATION_TESTS: list[QueryTestCase] = [
     QueryTestCase(
         id="compound_bitsAllSet_and_bitsAllClear",
         filter={"a": {"$bitsAllSet": 2, "$bitsAllClear": 1}},
@@ -141,9 +141,136 @@ OPERATOR_COMBINATION_TESTS: list[QueryTestCase] = [
 ]
 
 
-@pytest.mark.parametrize("test", pytest_params(OPERATOR_COMBINATION_TESTS))
-def test_bitsAllClear_operator_combinations(collection, test):
-    """Test $bitsAllClear combined with other query operators."""
+BITS_ALL_SET_COMBINATION_TESTS: list[QueryTestCase] = [
+    QueryTestCase(
+        id="contradictory_bitsAllSet_and_bitsAllClear",
+        filter={"a": {"$bitsAllSet": [1], "$bitsAllClear": [1]}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 1}, {"_id": 3, "a": 3}],
+        expected=[],
+        msg="Contradictory: bit 1 must be both set AND clear — always empty result",
+    ),
+    QueryTestCase(
+        id="bitsAllSet_with_not",
+        filter={"a": {"$not": {"$bitsAllSet": 1}}},
+        doc=[{"_id": 1, "a": 0}, {"_id": 2, "a": 1}, {"_id": 3, "a": 3}, {"_id": 4, "a": "str"}],
+        expected=[{"_id": 1, "a": 0}, {"_id": 4, "a": "str"}],
+        msg="$not inverts: matches docs where bit 0 is NOT set, plus non-numeric",
+    ),
+    QueryTestCase(
+        id="bitsAllSet_with_exists",
+        filter={"a": {"$exists": True, "$bitsAllSet": 1}},
+        doc=[{"_id": 1, "a": 1}, {"_id": 2, "b": 1}, {"_id": 3, "a": 0}],
+        expected=[{"_id": 1, "a": 1}],
+        msg="$exists true AND $bitsAllSet: field must exist and bit 0 set",
+    ),
+    QueryTestCase(
+        id="bitsAllSet_inside_elemMatch",
+        filter={"a": {"$elemMatch": {"$bitsAllSet": [0, 1]}}},
+        doc=[{"_id": 1, "a": [3, 20, 255]}, {"_id": 2, "a": [4, 8]}],
+        expected=[{"_id": 1, "a": [3, 20, 255]}],
+        msg="$elemMatch with $bitsAllSet on array of scalars",
+    ),
+    QueryTestCase(
+        id="type_int_with_bitsAllSet",
+        filter={"a": {"$type": "int", "$bitsAllSet": 1}},
+        doc=[
+            {"_id": 1, "a": 3},
+            {"_id": 2, "a": 2},
+            {"_id": 3, "a": "hello"},
+            {"_id": 4, "a": 3.0},
+        ],
+        expected=[{"_id": 1, "a": 3}],
+        msg="$type int AND $bitsAllSet: only int32 fields with bit 0 set",
+    ),
+    QueryTestCase(
+        id="bitsAllSet_with_gt",
+        filter={"a": {"$bitsAllSet": 3, "$gt": 5}},
+        doc=[
+            {"_id": 1, "a": 3},
+            {"_id": 2, "a": 7},
+            {"_id": 3, "a": 8},
+            {"_id": 4, "a": 15},
+        ],
+        expected=[{"_id": 2, "a": 7}, {"_id": 4, "a": 15}],
+        msg="$bitsAllSet bits 0,1 AND $gt 5: 7 and 15 have bits 0,1 set and > 5",
+    ),
+    QueryTestCase(
+        id="bitsAllSet_with_lt",
+        filter={"a": {"$bitsAllSet": 3, "$lt": 50}},
+        doc=[
+            {"_id": 1, "a": 3},
+            {"_id": 2, "a": 7},
+            {"_id": 3, "a": 55},
+            {"_id": 4, "a": 60},
+        ],
+        expected=[{"_id": 1, "a": 3}, {"_id": 2, "a": 7}],
+        msg="$bitsAllSet bits 0,1 AND $lt 50: 3 and 7 have bits 0,1 set and < 50",
+    ),
+    QueryTestCase(
+        id="bitsAllSet_with_gte_lte_range",
+        filter={"a": {"$bitsAllSet": 3, "$gte": 5, "$lte": 50}},
+        doc=[
+            {"_id": 1, "a": 3},
+            {"_id": 2, "a": 7},
+            {"_id": 3, "a": 15},
+            {"_id": 4, "a": 55},
+            {"_id": 5, "a": 8},
+        ],
+        expected=[{"_id": 2, "a": 7}, {"_id": 3, "a": 15}],
+        msg="$bitsAllSet bits 0,1 AND 5 <= a <= 50: 7 and 15 qualify",
+    ),
+    QueryTestCase(
+        id="and_bitsAllSet_across_fields",
+        filter={"$and": [{"a": {"$bitsAllSet": 1}}, {"b": {"$bitsAllSet": 2}}]},
+        doc=[
+            {"_id": 1, "a": 1, "b": 2},
+            {"_id": 2, "a": 1, "b": 1},
+            {"_id": 3, "a": 2, "b": 2},
+        ],
+        expected=[{"_id": 1, "a": 1, "b": 2}],
+        msg="$and: bit 0 set on field a AND bit 1 set on field b",
+    ),
+    QueryTestCase(
+        id="or_bitsAllSet_across_fields",
+        filter={"$or": [{"a": {"$bitsAllSet": 1}}, {"b": {"$bitsAllSet": 2}}]},
+        doc=[
+            {"_id": 1, "a": 1, "b": 0},
+            {"_id": 2, "a": 0, "b": 2},
+            {"_id": 3, "a": 0, "b": 0},
+        ],
+        expected=[{"_id": 1, "a": 1, "b": 0}, {"_id": 2, "a": 0, "b": 2}],
+        msg="$or: bit 0 set on field a OR bit 1 set on field b",
+    ),
+    QueryTestCase(
+        id="not_bitsAllSet_across_fields",
+        filter={"$and": [{"a": {"$not": {"$bitsAllSet": 1}}}, {"b": {"$not": {"$bitsAllSet": 2}}}]},
+        doc=[
+            {"_id": 1, "a": 0, "b": 1},
+            {"_id": 2, "a": 1, "b": 1},
+            {"_id": 3, "a": 0, "b": 2},
+        ],
+        expected=[{"_id": 1, "a": 0, "b": 1}],
+        msg="$not $bitsAllSet across fields: bit 0 NOT set on a AND bit 1 NOT set on b",
+    ),
+    QueryTestCase(
+        id="nor_bitsAllSet_across_fields",
+        filter={"$nor": [{"a": {"$bitsAllSet": 1}}, {"b": {"$bitsAllSet": 2}}]},
+        doc=[
+            {"_id": 1, "a": 0, "b": 1},
+            {"_id": 2, "a": 1, "b": 0},
+            {"_id": 3, "a": 0, "b": 0},
+        ],
+        expected=[{"_id": 1, "a": 0, "b": 1}, {"_id": 3, "a": 0, "b": 0}],
+        msg="$nor: neither bit 0 set on a NOR bit 1 set on b",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test", pytest_params(BITSALLCLEAR_COMBINATION_TESTS + BITS_ALL_SET_COMBINATION_TESTS)
+)
+def test_bitwise_operator_combinations(collection, test):
+    """Test $bitsAllClear and $bitsAllSet combined with other query operators."""
     collection.insert_many(test.doc)
     result = execute_command(collection, {"find": collection.name, "filter": test.filter})
     assertSuccess(result, test.expected, ignore_doc_order=True)


### PR DESCRIPTION
This PR added tests for bitsAllSetwith the following categories:

test_bitsAllSet_: test that specifically targets $bitsAllSet
test_query_combination_bitwise_operators.py: a sample of tests with mixed operators

Ref: Issue https://github.com/documentdb/functional-tests/issues/30

PR depends on #73 and #75 before these are merged, the unit test is expected not to pass.
