### PR TITLE
Add missing aggregate pytest marks

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_acceptance.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_acceptance.py
@@ -240,6 +240,7 @@ PROJECT_ACCEPTANCE_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(PROJECT_ACCEPTANCE_TESTS))
 def test_project_acceptance(collection: Any, test_case: StageTestCase) -> None:
     """Test $project accepted inputs."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_computed.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_computed.py
@@ -165,6 +165,7 @@ PROJECT_COMPUTED_ALL_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(PROJECT_COMPUTED_ALL_TESTS))
 def test_project_computed(collection: Any, test_case: StageTestCase) -> None:
     """Test $project computed fields."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_errors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_errors.py
@@ -520,6 +520,7 @@ PROJECT_ERROR_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(PROJECT_ERROR_TESTS))
 def test_project_errors(collection: Any, test_case: StageTestCase) -> None:
     """Test $project error cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_id.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_id.py
@@ -76,6 +76,7 @@ PROJECT_ID_BEHAVIOR_TESTS: list[StageTestCase] = [
 ]
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(PROJECT_ID_BEHAVIOR_TESTS))
 def test_project_id(collection: Any, test_case: StageTestCase) -> None:
     """Test $project _id field behavior."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_modes.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_modes.py
@@ -231,6 +231,7 @@ PROJECT_MODE_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(PROJECT_MODE_TESTS))
 def test_project_modes(collection: Any, test_case: StageTestCase) -> None:
     """Test $project inclusion and exclusion modes."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_paths.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/project/test_project_paths.py
@@ -283,6 +283,7 @@ PROJECT_PATH_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(PROJECT_PATH_TESTS))
 def test_project_paths(collection: Any, test_case: StageTestCase) -> None:
     """Test $project path resolution."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_bson_types.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_bson_types.py
@@ -227,6 +227,7 @@ SET_BSON_TYPE_TESTS: list[StageTestCase] = [
 
 
 @pytest.mark.parametrize("stage_name", STAGE_NAMES)
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SET_BSON_TYPE_TESTS))
 def test_set_bson_types(collection, stage_name: str, test_case: StageTestCase):
     """Test $set / $addFields BSON type pass-through cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_errors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_errors.py
@@ -322,6 +322,7 @@ SET_ERROR_TESTS = (
 
 
 @pytest.mark.parametrize("stage_name", STAGE_NAMES)
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SET_ERROR_TESTS))
 def test_set_errors(collection, stage_name: str, test_case: StageTestCase):
     """Test $set / $addFields error cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_field_names.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_field_names.py
@@ -122,6 +122,7 @@ SET_FIELD_NAME_TESTS = SET_FIELD_NAME_ACCEPTANCE_TESTS + SET_DOLLAR_SIGN_STRING_
 
 
 @pytest.mark.parametrize("stage_name", STAGE_NAMES)
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SET_FIELD_NAME_TESTS))
 def test_set_field_names(collection, stage_name: str, test_case: StageTestCase):
     """Test $set / $addFields field name acceptance and dollar-sign string cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_field_values.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_field_values.py
@@ -291,6 +291,7 @@ SET_FIELD_VALUE_TESTS = (
 
 
 @pytest.mark.parametrize("stage_name", STAGE_NAMES)
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SET_FIELD_VALUE_TESTS))
 def test_set_field_values(collection, stage_name: str, test_case: StageTestCase):
     """Test $set / $addFields field value cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_paths.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_paths.py
@@ -204,6 +204,7 @@ SET_PATH_TESTS = SET_SAME_STAGE_REF_TESTS + SET_DOT_NOTATION_TESTS + SET_EMBEDDE
 
 
 @pytest.mark.parametrize("stage_name", STAGE_NAMES)
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SET_PATH_TESTS))
 def test_set_paths(collection, stage_name: str, test_case: StageTestCase):
     """Test $set / $addFields path traversal and embedded object cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_pipeline.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/set/test_set_pipeline.py
@@ -78,6 +78,7 @@ SET_PIPELINE_TESTS = (
 
 
 @pytest.mark.parametrize("stage_name", STAGE_NAMES)
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SET_PIPELINE_TESTS))
 def test_set_pipeline(collection, stage_name: str, test_case: StageTestCase):
     """Test $set / $addFields pipeline-level behavior cases."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_arrays.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_arrays.py
@@ -205,6 +205,7 @@ SORT_ARRAY_KEY_TESTS: list[StageTestCase] = [
 ]
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_ARRAY_KEY_TESTS))
 def test_sort_arrays(collection, test_case: StageTestCase):
     """Test $sort array key extraction."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_basic_ordering.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_basic_ordering.py
@@ -417,6 +417,7 @@ SORT_BASIC_ORDERING_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_BASIC_ORDERING_TESTS))
 def test_sort_basic_ordering(collection, test_case: StageTestCase):
     """Test $sort ascending, descending, and equal-value ordering."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_direction_values.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_direction_values.py
@@ -144,6 +144,7 @@ SORT_META_ACCEPTANCE_TESTS: list[StageTestCase] = [
 SORT_DIRECTION_VALUE_TESTS = SORT_ORDER_VALUE_ACCEPTANCE_TESTS + SORT_META_ACCEPTANCE_TESTS
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_DIRECTION_VALUE_TESTS))
 def test_sort_direction_values(collection, test_case: StageTestCase):
     """Test $sort accepted direction values."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_field_paths.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_field_paths.py
@@ -190,6 +190,7 @@ SORT_FIELD_NAME_ACCEPTANCE_TESTS: list[StageTestCase] = [
 SORT_FIELD_PATH_TESTS = SORT_NESTED_FIELD_TESTS + SORT_FIELD_NAME_ACCEPTANCE_TESTS
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_FIELD_PATH_TESTS))
 def test_sort_field_paths(collection, test_case: StageTestCase):
     """Test $sort field path traversal and name acceptance."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_key_resolution.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_key_resolution.py
@@ -146,6 +146,7 @@ SORT_NULL_MISSING_TESTS: list[StageTestCase] = [
 SORT_KEY_RESOLUTION_TESTS = SORT_COMPOUND_TESTS + SORT_NULL_MISSING_TESTS
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_KEY_RESOLUTION_TESTS))
 def test_sort_key_resolution(collection, test_case: StageTestCase):
     """Test $sort compound keys, null, and missing fields."""
@@ -166,6 +167,7 @@ def test_sort_key_resolution(collection, test_case: StageTestCase):
     )
 
 
+@pytest.mark.aggregate
 def test_sort_key_resolution_timestamp_zero_replaced(collection):
     """Test $sort with Timestamp(0, 0) which is replaced by the server on insert."""
     collection.insert_many(

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_meta_errors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_meta_errors.py
@@ -232,6 +232,7 @@ SORT_META_ERROR_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_META_ERROR_TESTS))
 def test_sort_meta_errors(collection, test_case: StageTestCase):
     """Test $sort $meta validation errors."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_numeric.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_numeric.py
@@ -297,6 +297,7 @@ SORT_NUMERIC_ORDERING_TESTS: list[StageTestCase] = [
 ]
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_NUMERIC_ORDERING_TESTS))
 def test_sort_numeric(collection, test_case: StageTestCase):
     """Test $sort numeric type ordering."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_order_errors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_order_errors.py
@@ -330,6 +330,7 @@ SORT_ORDER_ERROR_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_ORDER_ERROR_TESTS))
 def test_sort_order_errors(collection, test_case: StageTestCase):
     """Test $sort order value type and range errors."""

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_spec_errors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_spec_errors.py
@@ -264,6 +264,7 @@ SORT_SPEC_ERROR_TESTS = (
 )
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_SPEC_ERROR_TESTS))
 def test_sort_spec_errors(collection, test_case: StageTestCase):
     """Test $sort specification and field path validation errors."""
@@ -292,6 +293,7 @@ def _build_raw_sort_stage(fields: list[tuple[str, int]]) -> RawBSONDocument:
     return RawBSONDocument(doc_len.to_bytes(4, "little") + stage_elements + b"\x00")
 
 
+@pytest.mark.aggregate
 def test_sort_spec_errors_duplicate_fields(collection):
     """Test $sort rejects duplicate field names in the sort specification."""
     collection.insert_many(

--- a/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_type_comparison.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/sort/test_sort_type_comparison.py
@@ -261,6 +261,7 @@ SORT_WITHIN_TYPE_TESTS: list[StageTestCase] = [
 SORT_TYPE_COMPARISON_TESTS = SORT_BSON_TYPE_ORDER_TESTS + SORT_WITHIN_TYPE_TESTS
 
 
+@pytest.mark.aggregate
 @pytest.mark.parametrize("test_case", pytest_params(SORT_TYPE_COMPARISON_TESTS))
 def test_sort_type_comparison(collection, test_case: StageTestCase):
     """Test $sort BSON type comparison ordering."""


### PR DESCRIPTION
This change adds the missing `@pytest.mark.aggregate` for aggregation stage tests which were already merged.