### PR TITLE
Add 79 smoke tests, replica_set marker: change streams, indexes (types/properties), collections (views/capped/timeseries), expressions, stages, sessions, administration, security

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ tests/
 - `smoke`: Quick smoke tests for feature detection
 - `slow`: Tests that take longer to execute
 - `no_parallel`: Tests that must run sequentially (e.g., tests that kill sessions/ops, modify server config, or drop all users/roles). Automatically deferred to Phase 2 when using `-n`.
+- `replica_set`: Tests that require a replica set topology (e.g., change streams, encryption, certain admin commands). Skipped by default in CI. To run locally, pass a replica set connection string: `pytest -m replica_set --connection-string "mongodb://localhost:27017/?directConnection=true"`
 
 ## Writing Tests
 

--- a/docs/SMOKE_TEST_NOTE.md
+++ b/docs/SMOKE_TEST_NOTE.md
@@ -1,0 +1,132 @@
+# Smoke Test Notes
+
+## Overview
+
+Smoke test files: 456
+Feature tree entries: 469
+Missing: 13
+
+## Missing Features (13)
+
+These features are replication related and not covered by smoke tests yet.
+
+- system > replication > commands > appendOplogNote
+- system > replication > commands > applyOps
+- system > replication > commands > hello
+- system > replication > commands > replSetAbortPrimaryCatchUp
+- system > replication > commands > replSetFreeze
+- system > replication > commands > replSetGetConfig
+- system > replication > commands > replSetGetStatus
+- system > replication > commands > replSetInitiate
+- system > replication > commands > replSetMaintenance
+- system > replication > commands > replSetReconfig
+- system > replication > commands > replSetResizeOplog
+- system > replication > commands > replSetStepDown
+- system > replication > commands > replSetSyncFrom
+
+## Assert-on-Failure Tests (6)
+
+These smoke tests verify that a command exists and is properly rejected with a specific
+error. The command is recognized by the server but fails due to preconditions (no active
+transaction, no encrypted collection, not permitted, etc.).
+
+| Feature | Code | Error Message | Reason |
+|---|---|---|---|
+| core/sessions/commands/abortTransaction | 125 | abortTransaction must be run within a transaction | No active transaction to abort |
+| core/sessions/commands/commitTransaction | 125 | commitTransaction must be run within a transaction | No active transaction to commit |
+| system/administration/commands/compactStructuredEncryptionData | 6346807 | Target namespace is not an encrypted collection | No encrypted collection exists |
+| system/administration/commands/setIndexCommitQuorum | 27 | Cannot find an index build on collection '...' with the provided index names | No active index build in progress |
+| system/administration/commands/shutdown | 13 (Unauthorized) | shutdown must run from localhost when running db without auth | Shutdown requires localhost or auth |
+| system/security/authentication/commands/authenticate | 18 (AuthenticationFailed) | Authentication failed. | Invalid credentials provided intentionally |
+
+## Replica Set Tests — Standalone Errors (24)
+
+These smoke tests are marked with `replica_set` and cannot run against a standalone MongoDB instance.
+They are automatically skipped when the server is not a replica set member.
+Below are the errors returned when running each against a standalone MongoDB instance.
+
+### Change Streams (16)
+
+All change stream tests fail with the same error:
+- **Code**: 40573 (Location40573)
+- **Message**: "The $changeStream stage is only supported on replica sets"
+
+| Feature | Test File |
+|---|---|
+| changeStreams/create | test_smoke_changeStream_create.py |
+| changeStreams/createIndexes | test_smoke_changeStream_createIndexes.py |
+| changeStreams/delete | test_smoke_changeStream_delete.py |
+| changeStreams/drop | test_smoke_changeStream_drop.py |
+| changeStreams/dropDatabase | test_smoke_changeStream_dropDatabase.py |
+| changeStreams/dropIndexes | test_smoke_changeStream_dropIndexes.py |
+| changeStreams/insert | test_smoke_changeStream_insert.py |
+| changeStreams/invalidate | test_smoke_changeStream_invalidate.py |
+| changeStreams/modify | test_smoke_changeStream_modify.py |
+| changeStreams/refineCollectionShardKey | test_smoke_changeStream_refineCollectionShardKey.py |
+| changeStreams/rename | test_smoke_changeStream_rename.py |
+| changeStreams/replace | test_smoke_changeStream_replace.py |
+| changeStreams/reshardCollection | test_smoke_changeStream_reshardCollection.py |
+| changeStreams/shardCollection | test_smoke_changeStream_shardCollection.py |
+| changeStreams/update | test_smoke_changeStream_update.py |
+| core/operator/system-stages/changeStream | test_smoke_changeStream.py |
+
+### Stages (2)
+
+| Feature | Code | Error Message |
+|---|---|---|
+| core/operator/stages/changeStreamSplitLargeEvent | 40573 | The $changeStream stage is only supported on replica sets |
+| core/operator/stages/listSampledQueries | 20 | $listSampledQueries is not supported on a standalone mongod |
+
+### Query Planning (2)
+
+| Feature | Code | Error Message |
+|---|---|---|
+| core/query-planning/commands/removeQuerySettings | 20 | removeQuerySettings can only run on replica sets or sharded clusters |
+| core/query-planning/commands/setQuerySettings | 20 | setQuerySettings can only run on replica sets or sharded clusters |
+
+### Administration (3)
+
+| Feature | Code | Error Message |
+|---|---|---|
+| system/administration/commands/getDefaultRWConcern | 51300 | 'getDefaultRWConcern' is not supported on standalone nodes. |
+| system/administration/commands/setDefaultRWConcern | 51300 | 'setDefaultRWConcern' is not supported on standalone nodes. |
+| system/administration/commands/setUserWriteBlockMode | 20 | setUserWriteBlockMode cannot be run on standalones |
+
+### Security (1)
+
+| Feature | Code | Error Message |
+|---|---|---|
+| system/security/encryption | 6346402 | Encrypted collections are not supported on standalone |
+
+## Hardcoded-Skip Tests — Standalone Errors (8)
+
+These smoke tests have `@pytest.mark.skip` decorators because they require infrastructure
+not available on standard MongoDB (sharded cluster, Atlas Search, or MongoDB Enterprise).
+
+### Auditing (1)
+
+| Feature | Code | Error Message |
+|---|---|---|
+| auditing/commands/logApplicationMessage | 59 | no such command: 'logApplicationMessage' (requires auditing to be enabled via --auditLog) |
+
+### Change Streams — Sharding (3)
+
+All three require a sharded cluster. On standalone, `$changeStream` itself fails first.
+
+| Feature | Code | Error Message |
+|---|---|---|
+| changeStreams/refineCollectionShardKey | 40573 | The $changeStream stage is only supported on replica sets |
+| changeStreams/reshardCollection | 40573 | The $changeStream stage is only supported on replica sets |
+| changeStreams/shardCollection | 40573 | The $changeStream stage is only supported on replica sets |
+
+### Atlas Search Stages (4)
+
+All four require Atlas Search, which is not available on standard MongoDB deployments.
+- **Code**: 31082 (SearchNotEnabled)
+
+| Feature | Code | Error Message |
+|---|---|---|
+| stages/listSearchIndexes | 31082 | Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration. |
+| stages/search | 31082 | Using $search and $vectorSearch aggregation stages requires additional configuration. |
+| stages/searchMeta | 31082 | Using $search and $vectorSearch aggregation stages requires additional configuration. |
+| stages/vectorSearch | 31082 | Using $search and $vectorSearch aggregation stages requires additional configuration. |

--- a/docs/feature-tree.csv
+++ b/docs/feature-tree.csv
@@ -3,7 +3,7 @@ core,aggregation,commands,-,-,aggregate
 core,aggregation,commands,-,-,count
 core,aggregation,commands,-,-,distinct
 core,aggregation,commands,-,-,mapReduce
-core,collections,-,-,-,capped_collections
+core,collections,-,-,-,capped-collections
 core,collections,-,-,-,clustered-collections
 core,collections,-,-,-,materialized-views
 core,collections,-,-,-,timeseries
@@ -66,7 +66,7 @@ core,operator,accumulators,-,-,sum
 core,operator,accumulators,-,-,top
 core,operator,accumulators,-,-,topN
 core,operator,expressions,-,-,literal
-core,operator,expressions,-,-,text
+core,operator,expressions,text,-,meta
 core,operator,expressions,accumulator,-,avg
 core,operator,expressions,accumulator,-,first
 core,operator,expressions,accumulator,-,last
@@ -153,7 +153,6 @@ core,operator,expressions,date,-,millisecond
 core,operator,expressions,date,-,minute
 core,operator,expressions,date,-,month
 core,operator,expressions,date,-,second
-core,operator,expressions,date,-,toDate
 core,operator,expressions,date,-,week
 core,operator,expressions,date,-,year
 core,operator,expressions,misc,-,binarySize
@@ -218,6 +217,7 @@ core,operator,expressions,type,-,toInt
 core,operator,expressions,type,-,toLong
 core,operator,expressions,type,-,toObjectId
 core,operator,expressions,type,-,toUUID
+core,operator,expressions,type,-,toDate
 core,operator,expressions,type,-,type
 core,operator,expressions,variable,-,let
 core,operator,projection,-,-,elemMatch

--- a/documentdb_tests/compatibility/tests/auditing/commands/logApplicationMessage/test_smoke_logApplicationMessage.py
+++ b/documentdb_tests/compatibility/tests/auditing/commands/logApplicationMessage/test_smoke_logApplicationMessage.py
@@ -1,0 +1,23 @@
+"""
+Smoke test for logApplicationMessage command.
+
+Tests basic logApplicationMessage functionality.
+Note: This command requires auditing to be enabled (--auditLog startup option).
+On servers without auditing, it returns CommandNotFound (code 59).
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.skip(reason="Requires auditing to be enabled")
+def test_smoke_logApplicationMessage(collection):
+    """Test basic logApplicationMessage behavior."""
+    result = execute_admin_command(collection, {"logApplicationMessage": "test message"})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support logApplicationMessage command")

--- a/documentdb_tests/compatibility/tests/changeStreams/create/test_smoke_changeStream_create.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/create/test_smoke_changeStream_create.py
@@ -1,0 +1,42 @@
+"""
+Smoke test for create change stream event.
+
+Tests basic create change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_create(collection):
+    """Test basic create change stream event behavior."""
+    result = execute_command(
+        collection,
+        {
+            "aggregate": 1,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "create"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    new_coll_name = f"{collection.name}_create_event"
+    execute_command(collection, {"create": new_coll_name})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": "$cmd.aggregate"})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "create",
+        "ns": {"db": collection.database.name, "coll": new_coll_name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support create change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/createIndexes/test_smoke_changeStream_createIndexes.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/createIndexes/test_smoke_changeStream_createIndexes.py
@@ -1,0 +1,46 @@
+"""
+Smoke test for createIndexes change stream event.
+
+Tests basic createIndexes change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_createIndexes(collection):
+    """Test basic createIndexes change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "createIndexes"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection,
+        {"createIndexes": collection.name, "indexes": [{"key": {"x": 1}, "name": "x_1"}]},
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "createIndexes",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support createIndexes change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/delete/test_smoke_changeStream_delete.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/delete/test_smoke_changeStream_delete.py
@@ -1,0 +1,42 @@
+"""
+Smoke test for delete change stream event.
+
+Tests basic delete change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_delete(collection):
+    """Test basic delete change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$changeStream": {}}, {"$match": {"operationType": "delete"}}],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection, {"delete": collection.name, "deletes": [{"q": {"_id": 1}, "limit": 1}]}
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "delete",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support delete change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/drop/test_smoke_changeStream_drop.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/drop/test_smoke_changeStream_drop.py
@@ -1,0 +1,40 @@
+"""
+Smoke test for drop change stream event.
+
+Tests basic drop change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_drop(collection):
+    """Test basic drop change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$changeStream": {}}, {"$match": {"operationType": "drop"}}],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(collection, {"drop": collection.name})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "drop",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support drop change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/dropDatabase/test_smoke_changeStream_dropDatabase.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/dropDatabase/test_smoke_changeStream_dropDatabase.py
@@ -1,0 +1,37 @@
+"""
+Smoke test for dropDatabase change stream event.
+
+Tests basic dropDatabase change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_dropDatabase(collection):
+    """Test basic dropDatabase change stream event behavior."""
+    execute_command(collection, {"create": f"{collection.name}_temp"})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": 1,
+            "pipeline": [{"$changeStream": {}}, {"$match": {"operationType": "dropDatabase"}}],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(collection, {"dropDatabase": 1})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": "$cmd.aggregate"})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {"operationType": "dropDatabase", "ns": {"db": collection.database.name}}
+    assertSuccessPartial(result, expected, msg="Should support dropDatabase change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/dropIndexes/test_smoke_changeStream_dropIndexes.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/dropIndexes/test_smoke_changeStream_dropIndexes.py
@@ -1,0 +1,45 @@
+"""
+Smoke test for dropIndexes change stream event.
+
+Tests basic dropIndexes change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_dropIndexes(collection):
+    """Test basic dropIndexes change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+    collection.create_index([("x", 1)])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "dropIndexes"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(collection, {"dropIndexes": collection.name, "index": "x_1"})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "dropIndexes",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support dropIndexes change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/insert/test_smoke_changeStream_insert.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/insert/test_smoke_changeStream_insert.py
@@ -1,0 +1,38 @@
+"""
+Smoke test for insert change stream event.
+
+Tests basic insert change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_insert(collection):
+    """Test basic insert change stream event behavior."""
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$changeStream": {}}, {"$match": {"operationType": "insert"}}],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(collection, {"insert": collection.name, "documents": [{"_id": 1, "x": 1}]})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "insert",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support insert change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/invalidate/test_smoke_changeStream_invalidate.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/invalidate/test_smoke_changeStream_invalidate.py
@@ -1,0 +1,33 @@
+"""
+Smoke test for invalidate change stream event.
+
+Tests basic invalidate change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_invalidate(collection):
+    """Test basic invalidate change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {"aggregate": collection.name, "pipeline": [{"$changeStream": {}}], "cursor": {}},
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(collection, {"drop": collection.name})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][1]
+
+    expected = {"operationType": "invalidate"}
+    assertSuccessPartial(result, expected, msg="Should support invalidate change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/modify/test_smoke_changeStream_modify.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/modify/test_smoke_changeStream_modify.py
@@ -1,0 +1,43 @@
+"""
+Smoke test for modify change stream event.
+
+Tests basic modify change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_modify(collection):
+    """Test basic modify change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "modify"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(collection, {"collMod": collection.name, "validator": {"x": {"$type": "int"}}})
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "modify",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support modify change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/refineCollectionShardKey/test_smoke_changeStream_refineCollectionShardKey.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/refineCollectionShardKey/test_smoke_changeStream_refineCollectionShardKey.py
@@ -1,0 +1,58 @@
+"""
+Smoke test for refineCollectionShardKey change stream event.
+
+Tests basic refineCollectionShardKey change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+@pytest.mark.skip(reason="refineCollectionShardKey operations not supported in this environment")
+def test_smoke_changeStream_refineCollectionShardKey(collection):
+    """Test basic refineCollectionShardKey change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1, "y": 1})
+
+    execute_command(
+        collection,
+        {"shardCollection": f"{collection.database.name}.{collection.name}", "key": {"x": 1}},
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "refineCollectionShardKey"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection,
+        {
+            "refineCollectionShardKey": f"{collection.database.name}.{collection.name}",
+            "key": {"x": 1, "y": 1},
+        },
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "refineCollectionShardKey",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(
+        result, expected, msg="Should support refineCollectionShardKey change stream event"
+    )

--- a/documentdb_tests/compatibility/tests/changeStreams/rename/test_smoke_changeStream_rename.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/rename/test_smoke_changeStream_rename.py
@@ -1,0 +1,49 @@
+"""
+Smoke test for rename change stream event.
+
+Tests basic rename change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command, execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_rename(collection):
+    """Test basic rename change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "rename"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_admin_command(
+        collection,
+        {
+            "renameCollection": f"{collection.database.name}.{collection.name}",
+            "to": f"{collection.database.name}.{collection.name}_renamed",
+        },
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "rename",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support rename change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/replace/test_smoke_changeStream_replace.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/replace/test_smoke_changeStream_replace.py
@@ -1,0 +1,43 @@
+"""
+Smoke test for replace change stream event.
+
+Tests basic replace change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_replace(collection):
+    """Test basic replace change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$changeStream": {}}, {"$match": {"operationType": "replace"}}],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection,
+        {"findAndModify": collection.name, "query": {"_id": 1}, "update": {"_id": 1, "y": 2.0}},
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "replace",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support replace change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/reshardCollection/test_smoke_changeStream_reshardCollection.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/reshardCollection/test_smoke_changeStream_reshardCollection.py
@@ -1,0 +1,50 @@
+"""
+Smoke test for reshardCollection change stream event.
+
+Tests basic reshardCollection change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+@pytest.mark.skip(reason="reshardCollection operations not supported in this environment")
+def test_smoke_changeStream_reshardCollection(collection):
+    """Test basic reshardCollection change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "reshardCollection"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection,
+        {"reshardCollection": f"{collection.database.name}.{collection.name}", "key": {"y": 1}},
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "reshardCollection",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(
+        result, expected, msg="Should support reshardCollection change stream event"
+    )

--- a/documentdb_tests/compatibility/tests/changeStreams/shardCollection/test_smoke_changeStream_shardCollection.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/shardCollection/test_smoke_changeStream_shardCollection.py
@@ -1,0 +1,46 @@
+"""
+Smoke test for shardCollection change stream event.
+
+Tests basic shardCollection change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+@pytest.mark.skip(reason="shardCollection events not captured even with showExpandedEvents")
+def test_smoke_changeStream_shardCollection(collection):
+    """Test basic shardCollection change stream event behavior."""
+    result = execute_command(
+        collection,
+        {
+            "aggregate": 1,
+            "pipeline": [
+                {"$changeStream": {"showExpandedEvents": True}},
+                {"$match": {"operationType": "shardCollection"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection,
+        {"shardCollection": f"{collection.database.name}.{collection.name}", "key": {"_id": 1}},
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": "$cmd.aggregate"})
+
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "shardCollection",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support shardCollection change stream event")

--- a/documentdb_tests/compatibility/tests/changeStreams/update/test_smoke_changeStream_update.py
+++ b/documentdb_tests/compatibility/tests/changeStreams/update/test_smoke_changeStream_update.py
@@ -1,0 +1,43 @@
+"""
+Smoke test for update change stream event.
+
+Tests basic update change stream event functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream_update(collection):
+    """Test basic update change stream event behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$changeStream": {}}, {"$match": {"operationType": "update"}}],
+            "cursor": {},
+        },
+    )
+
+    cursor_id = result["cursor"]["id"]
+
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$set": {"x": 2.0}}}]},
+    )
+
+    result = execute_command(collection, {"getMore": cursor_id, "collection": collection.name})
+    result = result["cursor"]["nextBatch"][0]
+
+    expected = {
+        "operationType": "update",
+        "ns": {"db": collection.database.name, "coll": collection.name},
+    }
+    assertSuccessPartial(result, expected, msg="Should support update change stream event")

--- a/documentdb_tests/compatibility/tests/core/collation/test_smoke_collation.py
+++ b/documentdb_tests/compatibility/tests/core/collation/test_smoke_collation.py
@@ -1,0 +1,32 @@
+"""
+Smoke test for collation.
+
+Tests basic collation functionality with locale-specific string comparison.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_collation(collection):
+    """Test basic collation behavior with case-insensitive comparison."""
+    execute_command(
+        collection,
+        {"create": f"{collection.name}_collated", "collation": {"locale": "en", "strength": 2.0}},
+    )
+
+    collated_collection = collection.database[f"{collection.name}_collated"]
+    collated_collection.insert_many(
+        [{"_id": 1, "name": "apple"}, {"_id": 2, "name": "Apple"}, {"_id": 3, "name": "banana"}]
+    )
+
+    result = execute_command(
+        collection, {"find": f"{collection.name}_collated", "filter": {"name": "apple"}}
+    )
+
+    expected = [{"_id": 1, "name": "apple"}, {"_id": 2, "name": "Apple"}]
+    assertSuccess(result, expected, msg="Should support collation with case-insensitive comparison")

--- a/documentdb_tests/compatibility/tests/core/collections/capped-collections/test_smoke_capped-collections.py
+++ b/documentdb_tests/compatibility/tests/core/collections/capped-collections/test_smoke_capped-collections.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for capped-collections.
+
+Tests basic capped collection functionality with size limit.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_capped_collections(collection):
+    """Test basic capped collection creation."""
+    result = execute_command(
+        collection, {"create": f"{collection.name}_capped", "capped": True, "size": 1024.0}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support creating capped collections")

--- a/documentdb_tests/compatibility/tests/core/collections/clustered-collections/test_smoke_clustered-collections.py
+++ b/documentdb_tests/compatibility/tests/core/collections/clustered-collections/test_smoke_clustered-collections.py
@@ -1,0 +1,26 @@
+"""
+Smoke test for clustered-collections.
+
+Tests basic clustered collection functionality with clustered index on _id.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_clustered_collections(collection):
+    """Test basic clustered collection creation."""
+    result = execute_command(
+        collection,
+        {
+            "create": f"{collection.name}_clustered",
+            "clusteredIndex": {"key": {"_id": 1}, "unique": True},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support creating clustered collections")

--- a/documentdb_tests/compatibility/tests/core/collections/commands/validateDBMetadata/test_smoke_validateDBMetadata.py
+++ b/documentdb_tests/compatibility/tests/core/collections/commands/validateDBMetadata/test_smoke_validateDBMetadata.py
@@ -1,0 +1,27 @@
+"""
+Smoke test for validateDBMetadata command.
+
+Tests basic database metadata validation functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_validateDBMetadata(collection):
+    """Test basic validateDBMetadata command."""
+    result = execute_admin_command(
+        collection,
+        {
+            "validateDBMetadata": 1,
+            "db": collection.database.name,
+            "apiParameters": {"version": "1", "strict": True},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support validateDBMetadata command")

--- a/documentdb_tests/compatibility/tests/core/collections/materialized-views/test_smoke_materialized-views.py
+++ b/documentdb_tests/compatibility/tests/core/collections/materialized-views/test_smoke_materialized-views.py
@@ -1,0 +1,40 @@
+"""
+Smoke test for materialized-views.
+
+Tests basic materialized view functionality using $merge stage.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_materialized_views(collection):
+    """Test basic materialized view creation using $merge."""
+    collection.insert_many(
+        [
+            {"_id": 1, "category": "A", "value": 10.0},
+            {"_id": 2, "category": "A", "value": 20.0},
+            {"_id": 3, "category": "B", "value": 30.0},
+        ]
+    )
+
+    execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$group": {"_id": "$category", "total": {"$sum": "$value"}}},
+                {"$merge": {"into": f"{collection.name}_view", "whenMatched": "replace"}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    result = execute_command(collection, {"find": f"{collection.name}_view", "sort": {"_id": 1}})
+
+    expected = [{"_id": "A", "total": 30.0}, {"_id": "B", "total": 30.0}]
+    assertSuccess(result, expected, msg="Should support creating materialized views with $merge")

--- a/documentdb_tests/compatibility/tests/core/collections/timeseries/test_smoke_timeseries.py
+++ b/documentdb_tests/compatibility/tests/core/collections/timeseries/test_smoke_timeseries.py
@@ -1,0 +1,30 @@
+"""
+Smoke test for timeseries.
+
+Tests basic timeseries collection functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_timeseries(collection):
+    """Test basic timeseries collection creation."""
+    result = execute_command(
+        collection,
+        {
+            "create": f"{collection.name}_timeseries",
+            "timeseries": {
+                "timeField": "timestamp",
+                "metaField": "metadata",
+                "granularity": "seconds",
+            },
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support creating timeseries collections")

--- a/documentdb_tests/compatibility/tests/core/collections/views/test_smoke_views.py
+++ b/documentdb_tests/compatibility/tests/core/collections/views/test_smoke_views.py
@@ -1,0 +1,40 @@
+"""
+Smoke test for views.
+
+Tests basic view functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_views(collection):
+    """Test basic view creation and querying."""
+    collection.insert_many(
+        [
+            {"_id": 1, "name": "Alice", "age": 30.0},
+            {"_id": 2, "name": "Bob", "age": 25.0},
+            {"_id": 3, "name": "Charlie", "age": 35.0},
+        ]
+    )
+
+    execute_command(
+        collection,
+        {
+            "create": f"{collection.name}_view",
+            "viewOn": collection.name,
+            "pipeline": [{"$match": {"age": {"$gte": 30}}}],
+        },
+    )
+
+    result = execute_command(collection, {"find": f"{collection.name}_view", "sort": {"_id": 1}})
+
+    expected = [
+        {"_id": 1, "name": "Alice", "age": 30.0},
+        {"_id": 3, "name": "Charlie", "age": 35.0},
+    ]
+    assertSuccess(result, expected, msg="Should support creating and querying views")

--- a/documentdb_tests/compatibility/tests/core/cursors/tailable-cursors/test_smoke_tailable-cursors.py
+++ b/documentdb_tests/compatibility/tests/core/cursors/tailable-cursors/test_smoke_tailable-cursors.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for tailable-cursors.
+
+Tests basic tailable cursor functionality on capped collections.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_tailable_cursors(collection):
+    """Test basic tailable cursor creation on capped collection."""
+    execute_command(
+        collection, {"create": f"{collection.name}_capped", "capped": True, "size": 4096.0}
+    )
+
+    capped_collection = collection.database[f"{collection.name}_capped"]
+    capped_collection.insert_many([{"_id": 1, "value": "test1"}, {"_id": 2, "value": "test2"}])
+
+    result = execute_command(
+        collection, {"find": f"{collection.name}_capped", "tailable": True, "awaitData": False}
+    )
+
+    expected = [{"_id": 1, "value": "test1"}, {"_id": 2, "value": "test2"}]
+    assertSuccess(result, expected, msg="Should support tailable cursors on capped collections")

--- a/documentdb_tests/compatibility/tests/core/data-types/bson-types/test_smoke_bson-types.py
+++ b/documentdb_tests/compatibility/tests/core/data-types/bson-types/test_smoke_bson-types.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for bson-types.
+
+Tests basic BSON type support including ObjectId, Date, and Binary.
+"""
+
+from datetime import datetime
+
+import pytest
+from bson import Binary, ObjectId
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_bson_types(collection):
+    """Test basic BSON type storage and retrieval."""
+    test_oid = ObjectId()
+    test_date = datetime(2024, 1, 1, 12, 0, 0)
+    test_binary = Binary(b"test data")
+
+    collection.insert_many([{"_id": 1, "oid": test_oid, "date": test_date, "binary": test_binary}])
+
+    result = execute_command(collection, {"find": collection.name, "filter": {"_id": 1}})
+
+    expected = [{"_id": 1, "oid": test_oid, "date": test_date, "binary": b"test data"}]
+    assertSuccess(result, expected, msg="Should support BSON types")

--- a/documentdb_tests/compatibility/tests/core/data-types/mongodb-extended-json/test_smoke_mongodb-extended-json.py
+++ b/documentdb_tests/compatibility/tests/core/data-types/mongodb-extended-json/test_smoke_mongodb-extended-json.py
@@ -1,0 +1,32 @@
+"""
+Smoke test for mongodb-extended-json.
+
+Tests basic MongoDB Extended JSON support for special types.
+"""
+
+from datetime import datetime
+
+import pytest
+from bson import Decimal128
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_mongodb_extended_json(collection):
+    """Test basic Extended JSON type support."""
+    test_date = datetime(2024, 1, 1, 12, 0, 0)
+    test_decimal = Decimal128("123.45")
+
+    collection.insert_many(
+        [{"_id": 1, "date": test_date, "decimal": test_decimal, "int64": 9223372036854775807.0}]
+    )
+
+    result = execute_command(collection, {"find": collection.name, "filter": {"_id": 1}})
+
+    expected = [
+        {"_id": 1, "date": test_date, "decimal": test_decimal, "int64": 9223372036854775807.0}
+    ]
+    assertSuccess(result, expected, msg="Should support MongoDB Extended JSON types")

--- a/documentdb_tests/compatibility/tests/core/indexes/properties/case-insensitive/test_smoke_case-insensitive.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/properties/case-insensitive/test_smoke_case-insensitive.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for case-insensitive index property.
+
+Tests basic case-insensitive index functionality using collation.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_case_insensitive(collection):
+    """Test basic case-insensitive index behavior."""
+    collection.insert_many([{"_id": 1, "name": "Alice"}, {"_id": 2, "name": "bob"}])
+
+    collection.create_index([("name", 1)], collation={"locale": "en", "strength": 2.0})
+
+    result = execute_command(
+        collection,
+        {
+            "find": collection.name,
+            "filter": {"name": "ALICE"},
+            "collation": {"locale": "en", "strength": 2.0},
+        },
+    )
+
+    expected = [{"_id": 1, "name": "Alice"}]
+    assertSuccess(result, expected, msg="Should support case-insensitive index with collation")

--- a/documentdb_tests/compatibility/tests/core/indexes/properties/hidden/test_smoke_hidden.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/properties/hidden/test_smoke_hidden.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for hidden index property.
+
+Tests basic hidden index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_hidden(collection):
+    """Test basic hidden index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"status": 1}, "name": "status_1", "hidden": True}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support hidden index property")

--- a/documentdb_tests/compatibility/tests/core/indexes/properties/partial/test_smoke_partial.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/properties/partial/test_smoke_partial.py
@@ -1,0 +1,37 @@
+"""
+Smoke test for partial index property.
+
+Tests basic partial index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_partial(collection):
+    """Test basic partial index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [
+                {
+                    "key": {"score": 1},
+                    "name": "score_partial",
+                    "partialFilterExpression": {"score": {"$gt": 80}},
+                }
+            ],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support partial index property")

--- a/documentdb_tests/compatibility/tests/core/indexes/properties/sparse/test_smoke_sparse.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/properties/sparse/test_smoke_sparse.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for sparse index property.
+
+Tests basic sparse index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_sparse(collection):
+    """Test basic sparse index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"email": 1}, "name": "email_sparse", "sparse": True}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support sparse index property")

--- a/documentdb_tests/compatibility/tests/core/indexes/properties/ttl/test_smoke_ttl.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/properties/ttl/test_smoke_ttl.py
@@ -1,0 +1,33 @@
+"""
+Smoke test for ttl index property.
+
+Tests basic TTL index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_ttl(collection):
+    """Test basic ttl index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [
+                {"key": {"createdAt": 1}, "name": "createdAt_ttl", "expireAfterSeconds": 3600.0}
+            ],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support ttl index property")

--- a/documentdb_tests/compatibility/tests/core/indexes/properties/unique/test_smoke_unique.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/properties/unique/test_smoke_unique.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for unique index property.
+
+Tests basic unique index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_unique(collection):
+    """Test basic unique index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"email": 1}, "name": "email_unique", "unique": True}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support unique index property")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/compound/test_smoke_compound.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/compound/test_smoke_compound.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for compound index type.
+
+Tests basic compound index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_compound(collection):
+    """Test basic compound index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"lastName": 1, "firstName": 1}, "name": "name_compound"}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support compound index type")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/geospatial/test_smoke_geospatial.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/geospatial/test_smoke_geospatial.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for geospatial index type.
+
+Tests basic geospatial index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_geospatial(collection):
+    """Test basic geospatial index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"location": "2dsphere"}, "name": "location_2dsphere"}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support geospatial index type")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/hashed/test_smoke_hashed.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/hashed/test_smoke_hashed.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for hashed index type.
+
+Tests basic hashed index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_hashed(collection):
+    """Test basic hashed index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"userId": "hashed"}, "name": "userId_hashed"}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support hashed index type")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/multikey/test_smoke_multikey.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/multikey/test_smoke_multikey.py
@@ -1,0 +1,35 @@
+"""
+Smoke test for multikey index type.
+
+Tests basic multikey index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_multikey(collection):
+    """Test basic multikey index behavior."""
+    collection.insert_many(
+        [{"_id": 1, "tags": ["mongodb", "database"]}, {"_id": 2, "tags": ["nosql", "database"]}]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"tags": 1}, "name": "tags_multikey"}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": False,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support multikey index type")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/single/test_smoke_single.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/single/test_smoke_single.py
@@ -1,0 +1,28 @@
+"""
+Smoke test for single index type.
+
+Tests basic single field index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_single(collection):
+    """Test basic single field index behavior."""
+    result = execute_command(
+        collection,
+        {"createIndexes": collection.name, "indexes": [{"key": {"name": 1}, "name": "name_1"}]},
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support single field index type")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/text/test_smoke_indexes_text.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/text/test_smoke_indexes_text.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for text index type.
+
+Tests basic text index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_text(collection):
+    """Test basic text index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"description": "text"}, "name": "description_text"}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support text index type")

--- a/documentdb_tests/compatibility/tests/core/indexes/types/wildcard/test_smoke_wildcard.py
+++ b/documentdb_tests/compatibility/tests/core/indexes/types/wildcard/test_smoke_wildcard.py
@@ -1,0 +1,31 @@
+"""
+Smoke test for wildcard index type.
+
+Tests basic wildcard index functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_indexes_wildcard(collection):
+    """Test basic wildcard index behavior."""
+    result = execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [{"key": {"$**": 1}, "name": "wildcard_index"}],
+        },
+    )
+
+    expected = {
+        "numIndexesBefore": 1,
+        "numIndexesAfter": 2,
+        "createdCollectionAutomatically": True,
+        "ok": 1.0,
+    }
+    assertSuccessPartial(result, expected, msg="Should support wildcard index type")

--- a/documentdb_tests/compatibility/tests/core/operator/accumulators/concatArrays/test_smoke_accumulator_concatArrays.py
+++ b/documentdb_tests/compatibility/tests/core/operator/accumulators/concatArrays/test_smoke_accumulator_concatArrays.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for $concatArrays accumulator.
+
+Tests basic $concatArrays accumulator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_accumulator_concatArrays(collection):
+    """Test basic $concatArrays accumulator behavior."""
+    collection.insert_many([{"_id": 1, "category": "A", "items": [1, 2, 3, 4]}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$group": {"_id": "$category", "allItems": {"$concatArrays": "$items"}}}],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": "A", "allItems": [1, 2, 3, 4]}]
+    assertSuccess(result, expected, msg="Should support $concatArrays accumulator")

--- a/documentdb_tests/compatibility/tests/core/operator/aggregation/expressions/text/meta/test_smoke_meta.py
+++ b/documentdb_tests/compatibility/tests/core/operator/aggregation/expressions/text/meta/test_smoke_meta.py
@@ -1,0 +1,33 @@
+"""
+Smoke test for $meta expression.
+
+Tests basic $meta expression functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_meta(collection):
+    """Test basic $meta expression behavior."""
+    collection.create_index([("description", "text")])
+    collection.insert_many([{"_id": 1, "description": "mongodb database"}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {"$match": {"$text": {"$search": "mongodb"}}},
+                {"$project": {"score": {"$meta": "textScore"}}},
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $meta expression")

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/custom/function/test_smoke_function.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/custom/function/test_smoke_function.py
@@ -1,0 +1,41 @@
+"""
+Smoke test for $function custom expression.
+
+Tests basic $function custom expression functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_function(collection):
+    """Test basic $function custom expression behavior."""
+    collection.insert_many([{"_id": 1, "value": 5.0}, {"_id": 2, "value": 10.0}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$project": {
+                        "doubled": {
+                            "$function": {
+                                "body": "function(x) { return x * 2; }",
+                                "args": ["$value"],
+                                "lang": "js",
+                            }
+                        }
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": 1, "doubled": 10.0}, {"_id": 2, "doubled": 20.0}]
+    assertSuccess(result, expected, msg="Should support $function custom expression")

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/custom/operator_accumulator/test_smoke_operator_accumulator.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/custom/operator_accumulator/test_smoke_operator_accumulator.py
@@ -1,0 +1,46 @@
+"""
+Smoke test for $accumulator custom expression.
+
+Tests basic $accumulator custom expression functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_operator_accumulator(collection):
+    """Test basic $accumulator custom expression behavior."""
+    collection.insert_many(
+        [{"_id": 1, "category": "A", "value": 5.0}, {"_id": 2, "category": "A", "value": 10.0}]
+    )
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$group": {
+                        "_id": "$category",
+                        "total": {
+                            "$accumulator": {
+                                "init": "function() { return 0; }",
+                                "accumulate": "function(state, value) { return state + value; }",
+                                "accumulateArgs": ["$value"],
+                                "merge": "function(state1, state2) { return state1 + state2; }",
+                                "lang": "js",
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": "A", "total": 15.0}]
+    assertSuccess(result, expected, msg="Should support $accumulator custom expression")

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/literal/test_smoke_literal.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/literal/test_smoke_literal.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for $literal expression.
+
+Tests basic $literal expression functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_literal(collection):
+    """Test basic $literal expression behavior."""
+    collection.insert_many([{"_id": 1, "name": "test"}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$project": {"literalValue": {"$literal": "$field"}}}],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": 1, "literalValue": "$field"}]
+    assertSuccess(result, expected, msg="Should support $literal expression")

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/misc/toHashedIndexKey/test_smoke_toHashedIndexKey.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/misc/toHashedIndexKey/test_smoke_toHashedIndexKey.py
@@ -1,0 +1,29 @@
+"""
+Smoke test for $toHashedIndexKey expression.
+
+Tests basic $toHashedIndexKey expression functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_toHashedIndexKey(collection):
+    """Test basic $toHashedIndexKey expression behavior."""
+    collection.insert_many([{"_id": 1, "userId": "user123"}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$project": {"hashedKey": {"$toHashedIndexKey": "$userId"}}}],
+            "cursor": {},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $toHashedIndexKey expression")

--- a/documentdb_tests/compatibility/tests/core/operator/expressions/variable/let/test_smoke_let.py
+++ b/documentdb_tests/compatibility/tests/core/operator/expressions/variable/let/test_smoke_let.py
@@ -1,0 +1,40 @@
+"""
+Smoke test for $let variable expression.
+
+Tests basic $let variable expression functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_let(collection):
+    """Test basic $let variable expression behavior."""
+    collection.insert_many([{"_id": 1, "price": 10.0, "quantity": 5.0}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$project": {
+                        "total": {
+                            "$let": {
+                                "vars": {"p": "$price", "q": "$quantity"},
+                                "in": {"$multiply": ["$$p", "$$q"]},
+                            }
+                        }
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": 1, "total": 50.0}]
+    assertSuccess(result, expected, msg="Should support $let variable expression")

--- a/documentdb_tests/compatibility/tests/core/operator/query/text/test_smoke_query_text.py
+++ b/documentdb_tests/compatibility/tests/core/operator/query/text/test_smoke_query_text.py
@@ -1,0 +1,25 @@
+"""
+Smoke test for $text query operator.
+
+Tests basic $text query operator functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_query_text(collection):
+    """Test basic $text query operator behavior."""
+    collection.create_index([("description", "text")])
+    collection.insert_many([{"_id": 1, "description": "mongodb database"}])
+
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"$text": {"$search": "mongodb"}}}
+    )
+
+    expected = [{"_id": 1, "description": "mongodb database"}]
+    assertSuccess(result, expected, msg="Should support $text query operator")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/changeStreamSplitLargeEvent/test_smoke_changeStreamSplitLargeEvent.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/changeStreamSplitLargeEvent/test_smoke_changeStreamSplitLargeEvent.py
@@ -1,0 +1,28 @@
+"""
+Smoke test for $changeStreamSplitLargeEvent stage.
+
+Tests basic $changeStreamSplitLargeEvent stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStreamSplitLargeEvent(collection):
+    """Test basic $changeStreamSplitLargeEvent stage behavior."""
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$changeStream": {}}, {"$changeStreamSplitLargeEvent": {}}],
+            "cursor": {},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $changeStreamSplitLargeEvent stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/listClusterCatalog/test_smoke_listClusterCatalog.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/listClusterCatalog/test_smoke_listClusterCatalog.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for $listClusterCatalog stage.
+
+Tests basic $listClusterCatalog stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_listClusterCatalog(collection):
+    """Test basic $listClusterCatalog stage behavior."""
+    result = execute_admin_command(
+        collection, {"aggregate": 1, "pipeline": [{"$listClusterCatalog": {}}], "cursor": {}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $listClusterCatalog stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/listSampledQueries/test_smoke_listSampledQueries.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/listSampledQueries/test_smoke_listSampledQueries.py
@@ -1,0 +1,23 @@
+"""
+Smoke test for $listSampledQueries stage.
+
+Tests basic $listSampledQueries stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_listSampledQueries(collection):
+    """Test basic $listSampledQueries stage behavior."""
+    result = execute_admin_command(
+        collection, {"aggregate": 1, "pipeline": [{"$listSampledQueries": {}}], "cursor": {}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $listSampledQueries stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/listSearchIndexes/test_smoke_listSearchIndexes.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/listSearchIndexes/test_smoke_listSearchIndexes.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for $listSearchIndexes stage.
+
+Tests basic $listSearchIndexes stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.skip(reason="Requires Atlas Search configuration - not available on standard MongoDB")
+def test_smoke_listSearchIndexes(collection):
+    """Test basic $listSearchIndexes stage behavior."""
+    result = execute_command(
+        collection,
+        {"aggregate": collection.name, "pipeline": [{"$listSearchIndexes": {}}], "cursor": {}},
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $listSearchIndexes stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/listSessions/test_smoke_listSessions.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/listSessions/test_smoke_listSessions.py
@@ -1,0 +1,27 @@
+"""
+Smoke test for $listSessions stage.
+
+Tests basic $listSessions stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_listSessions(collection):
+    """Test basic $listSessions stage behavior."""
+    # $listSessions must run against config.system.sessions
+    config_db = collection.database.client["config"]
+    system_sessions = config_db["system.sessions"]
+
+    result = execute_command(
+        system_sessions,
+        {"aggregate": "system.sessions", "pipeline": [{"$listSessions": {}}], "cursor": {}},
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $listSessions stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/querySettings/test_smoke_querySettings.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/querySettings/test_smoke_querySettings.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for $querySettings stage.
+
+Tests basic $querySettings stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_querySettings(collection):
+    """Test basic $querySettings stage behavior."""
+    result = execute_admin_command(
+        collection, {"aggregate": 1, "pipeline": [{"$querySettings": {}}], "cursor": {}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $querySettings stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/queryStats/test_smoke_queryStats.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/queryStats/test_smoke_queryStats.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for $queryStats stage.
+
+Tests basic $queryStats stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_queryStats(collection):
+    """Test basic $queryStats stage behavior."""
+    result = execute_admin_command(
+        collection, {"aggregate": 1, "pipeline": [{"$queryStats": {}}], "cursor": {}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $queryStats stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/rankFusion/test_smoke_rankFusion.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/rankFusion/test_smoke_rankFusion.py
@@ -1,0 +1,39 @@
+"""
+Smoke test for $rankFusion stage.
+
+Tests basic $rankFusion stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_rankFusion(collection):
+    """Test basic $rankFusion stage behavior."""
+    collection.insert_many([{"_id": 1, "name": "test", "score": 10.0}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$rankFusion": {
+                        "input": {
+                            "pipelines": {
+                                "pipeline1": [{"$match": {"_id": 1}}, {"$sort": {"score": -1}}]
+                            }
+                        }
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": 1, "name": "test", "score": 10.0}]
+    assertSuccess(result, expected, msg="Should support $rankFusion stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/search/test_smoke_search.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/search/test_smoke_search.py
@@ -1,0 +1,30 @@
+"""
+Smoke test for $search stage.
+
+Tests basic $search stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.skip(reason="Requires Atlas Search configuration - not available on standard MongoDB")
+def test_smoke_search(collection):
+    """Test basic $search stage behavior."""
+    collection.insert_many([{"_id": 1, "title": "test document"}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$search": {"text": {"query": "test", "path": "title"}}}],
+            "cursor": {},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $search stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/searchMeta/test_smoke_searchMeta.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/searchMeta/test_smoke_searchMeta.py
@@ -1,0 +1,30 @@
+"""
+Smoke test for $searchMeta stage.
+
+Tests basic $searchMeta stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.skip(reason="Requires Atlas Search configuration - not available on standard MongoDB")
+def test_smoke_searchMeta(collection):
+    """Test basic $searchMeta stage behavior."""
+    collection.insert_many([{"_id": 1, "title": "test document"}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [{"$searchMeta": {"text": {"query": "test", "path": "title"}}}],
+            "cursor": {},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $searchMeta stage")

--- a/documentdb_tests/compatibility/tests/core/operator/stages/vectorSearch/test_smoke_vectorSearch.py
+++ b/documentdb_tests/compatibility/tests/core/operator/stages/vectorSearch/test_smoke_vectorSearch.py
@@ -1,0 +1,55 @@
+"""
+Smoke test for $vectorSearch stage.
+
+Tests basic $vectorSearch stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.skip(reason="Requires Atlas Search configuration - not available on standard MongoDB")
+def test_smoke_vectorSearch(collection):
+    """Test basic $vectorSearch stage behavior."""
+    # Create vector index with vectorOptions
+    execute_command(
+        collection,
+        {
+            "createIndexes": collection.name,
+            "indexes": [
+                {
+                    "key": {"embedding": "vector"},
+                    "name": "embedding_vector",
+                    "vectorOptions": {"type": "hnsw", "dimensions": 3.0, "similarity": "euclidean"},
+                }
+            ],
+        },
+    )
+
+    collection.insert_many([{"_id": 1, "name": "test", "embedding": [0.1, 0.2, 0.3]}])
+
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$vectorSearch": {
+                        "queryVector": [0.1, 0.2, 0.3],
+                        "path": "embedding",
+                        "numCandidates": 10.0,
+                        "limit": 5.0,
+                        "index": "embedding_vector",
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+
+    expected = [{"_id": 1, "name": "test", "embedding": [0.1, 0.2, 0.3]}]
+    assertSuccess(result, expected, msg="Should support $vectorSearch stage")

--- a/documentdb_tests/compatibility/tests/core/operator/system-stages/changeStream/test_smoke_changeStream.py
+++ b/documentdb_tests/compatibility/tests/core/operator/system-stages/changeStream/test_smoke_changeStream.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for $changeStream system stage.
+
+Tests basic $changeStream system stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_changeStream(collection):
+    """Test basic $changeStream system stage behavior."""
+    result = execute_command(
+        collection,
+        {"aggregate": collection.name, "pipeline": [{"$changeStream": {}}], "cursor": {}},
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $changeStream system stage")

--- a/documentdb_tests/compatibility/tests/core/operator/system-stages/currentOp/test_smoke_system_stage_currentOp.py
+++ b/documentdb_tests/compatibility/tests/core/operator/system-stages/currentOp/test_smoke_system_stage_currentOp.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for $currentOp system stage.
+
+Tests basic $currentOp system stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_system_stage_currentOp(collection):
+    """Test basic $currentOp system stage behavior."""
+    result = execute_admin_command(
+        collection, {"aggregate": 1, "pipeline": [{"$currentOp": {}}], "cursor": {}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $currentOp system stage")

--- a/documentdb_tests/compatibility/tests/core/operator/system-stages/documents/test_smoke_documents.py
+++ b/documentdb_tests/compatibility/tests/core/operator/system-stages/documents/test_smoke_documents.py
@@ -1,0 +1,23 @@
+"""
+Smoke test for $documents system stage.
+
+Tests basic $documents system stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_documents(collection):
+    """Test basic $documents system stage behavior."""
+    result = execute_admin_command(
+        collection,
+        {"aggregate": 1, "pipeline": [{"$documents": [{"_id": 1, "name": "test"}]}], "cursor": {}},
+    )
+
+    expected = [{"_id": 1, "name": "test"}]
+    assertSuccess(result, expected, msg="Should support $documents system stage")

--- a/documentdb_tests/compatibility/tests/core/operator/system-stages/listLocalSessions/test_smoke_listLocalSessions.py
+++ b/documentdb_tests/compatibility/tests/core/operator/system-stages/listLocalSessions/test_smoke_listLocalSessions.py
@@ -1,0 +1,22 @@
+"""
+Smoke test for $listLocalSessions system stage.
+
+Tests basic $listLocalSessions system stage functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_listLocalSessions(collection):
+    """Test basic $listLocalSessions system stage behavior."""
+    result = execute_admin_command(
+        collection, {"aggregate": 1, "pipeline": [{"$listLocalSessions": {}}], "cursor": {}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support $listLocalSessions system stage")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/read-concern/test_smoke_read-concern.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/read-concern/test_smoke_read-concern.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for readConcern.
+
+Tests basic readConcern functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_read_concern(collection):
+    """Test basic readConcern behavior."""
+    collection.insert_many([{"_id": 1, "name": "test"}])
+
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {}, "readConcern": {"level": "local"}}
+    )
+
+    expected = [{"_id": 1, "name": "test"}]
+    assertSuccess(result, expected, msg="Should support readConcern")

--- a/documentdb_tests/compatibility/tests/core/query-and-write/write-concern/test_smoke_write-concern.py
+++ b/documentdb_tests/compatibility/tests/core/query-and-write/write-concern/test_smoke_write-concern.py
@@ -1,0 +1,27 @@
+"""
+Smoke test for writeConcern.
+
+Tests basic writeConcern functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_write_concern(collection):
+    """Test basic writeConcern behavior."""
+    result = execute_command(
+        collection,
+        {
+            "insert": collection.name,
+            "documents": [{"_id": 1, "name": "test"}],
+            "writeConcern": {"w": 1},
+        },
+    )
+
+    expected = {"ok": 1.0, "n": 1}
+    assertSuccessPartial(result, expected, msg="Should support writeConcern")

--- a/documentdb_tests/compatibility/tests/core/query-planning/commands/removeQuerySettings/test_smoke_removeQuerySettings.py
+++ b/documentdb_tests/compatibility/tests/core/query-planning/commands/removeQuerySettings/test_smoke_removeQuerySettings.py
@@ -1,0 +1,32 @@
+"""
+Smoke test for removeQuerySettings command.
+
+Tests basic removeQuerySettings command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_removeQuerySettings(collection):
+    """Test basic removeQuerySettings command behavior."""
+    collection.insert_one({"_id": 1, "name": "Alice"})
+
+    result = execute_admin_command(
+        collection,
+        {
+            "removeQuerySettings": {
+                "find": collection.name,
+                "filter": {"name": "Alice"},
+                "$db": collection.database.name,
+            }
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support removeQuerySettings command")

--- a/documentdb_tests/compatibility/tests/core/query-planning/commands/setQuerySettings/test_smoke_setQuerySettings.py
+++ b/documentdb_tests/compatibility/tests/core/query-planning/commands/setQuerySettings/test_smoke_setQuerySettings.py
@@ -1,0 +1,33 @@
+"""
+Smoke test for setQuerySettings command.
+
+Tests basic setQuerySettings command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_setQuerySettings(collection):
+    """Test basic setQuerySettings command behavior."""
+    collection.insert_one({"_id": 1, "name": "Alice"})
+
+    result = execute_admin_command(
+        collection,
+        {
+            "setQuerySettings": {
+                "find": collection.name,
+                "filter": {"name": "Alice"},
+                "$db": collection.database.name,
+            },
+            "settings": {"queryFramework": "classic"},
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support setQuerySettings command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/abortTransaction/test_smoke_abortTransaction.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/abortTransaction/test_smoke_abortTransaction.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for abortTransaction command.
+
+Tests basic abortTransaction command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertFailure
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_abortTransaction(collection):
+    """Test basic abortTransaction command behavior."""
+    result = execute_admin_command(collection, {"abortTransaction": 1})
+
+    expected_error = {"code": 125, "msg": "abortTransaction must be run within a transaction"}
+    assertFailure(result, expected_error, msg="Should support abortTransaction command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/commitTransaction/test_smoke_commitTransaction.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/commitTransaction/test_smoke_commitTransaction.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for commitTransaction command.
+
+Tests basic commitTransaction command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertFailure
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_commitTransaction(collection):
+    """Test basic commitTransaction command behavior."""
+    result = execute_admin_command(collection, {"commitTransaction": 1})
+
+    expected_error = {"code": 125, "msg": "commitTransaction must be run within a transaction"}
+    assertFailure(result, expected_error, msg="Should support commitTransaction command")

--- a/documentdb_tests/compatibility/tests/core/sessions/commands/startSession/test_smoke_startSession.py
+++ b/documentdb_tests/compatibility/tests/core/sessions/commands/startSession/test_smoke_startSession.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for startSession command.
+
+Tests basic startSession command functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_startSession(collection):
+    """Test basic startSession command behavior."""
+    result = execute_command(collection, {"startSession": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support startSession command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/compactStructuredEncryptionData/test_smoke_compactStructuredEncryptionData.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/compactStructuredEncryptionData/test_smoke_compactStructuredEncryptionData.py
@@ -1,0 +1,24 @@
+"""
+Smoke test for compactStructuredEncryptionData command.
+
+Tests basic compactStructuredEncryptionData functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertFailure
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_compactStructuredEncryptionData(collection):
+    """Test basic compactStructuredEncryptionData behavior."""
+    collection.insert_one({"_id": 1})
+
+    result = execute_command(
+        collection, {"compactStructuredEncryptionData": collection.name, "compactionTokens": {}}
+    )
+
+    expected = {"code": 6346807, "msg": "Target namespace is not an encrypted collection"}
+    assertFailure(result, expected, msg="Should support compactStructuredEncryptionData command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/fsyncUnlock/test_smoke_fsyncUnlock.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/fsyncUnlock/test_smoke_fsyncUnlock.py
@@ -1,0 +1,25 @@
+"""
+Smoke test for fsyncUnlock command.
+
+Tests basic fsyncUnlock functionality by first locking with fsync,
+then unlocking with fsyncUnlock.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = [pytest.mark.smoke, pytest.mark.no_parallel]
+
+
+def test_smoke_fsyncUnlock(collection):
+    """Test basic fsyncUnlock behavior."""
+    # Lock first
+    execute_admin_command(collection, {"fsync": 1, "lock": True})
+
+    # Unlock
+    result = execute_admin_command(collection, {"fsyncUnlock": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support fsyncUnlock command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/getDefaultRWConcern/test_smoke_getDefaultRWConcern.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/getDefaultRWConcern/test_smoke_getDefaultRWConcern.py
@@ -1,0 +1,21 @@
+"""
+Smoke test for getDefaultRWConcern command.
+
+Tests basic getDefaultRWConcern functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_getDefaultRWConcern(collection):
+    """Test basic getDefaultRWConcern behavior."""
+    result = execute_admin_command(collection, {"getDefaultRWConcern": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support getDefaultRWConcern command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/setDefaultRWConcern/test_smoke_setDefaultRWConcern.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/setDefaultRWConcern/test_smoke_setDefaultRWConcern.py
@@ -1,0 +1,23 @@
+"""
+Smoke test for setDefaultRWConcern command.
+
+Tests basic setDefaultRWConcern functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_setDefaultRWConcern(collection):
+    """Test basic setDefaultRWConcern behavior."""
+    result = execute_admin_command(
+        collection, {"setDefaultRWConcern": 1, "defaultReadConcern": {"level": "local"}}
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support setDefaultRWConcern command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/setIndexCommitQuorum/test_smoke_setIndexCommitQuorum.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/setIndexCommitQuorum/test_smoke_setIndexCommitQuorum.py
@@ -1,0 +1,37 @@
+"""
+Smoke test for setIndexCommitQuorum command.
+
+Tests basic setIndexCommitQuorum functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertFailure
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_setIndexCommitQuorum(collection):
+    """Test basic setIndexCommitQuorum behavior."""
+    collection.insert_one({"_id": 1, "x": 1})
+    collection.create_index([("x", 1)])
+
+    result = execute_command(
+        collection,
+        {
+            "setIndexCommitQuorum": collection.name,
+            "indexNames": ["x_1"],
+            "commitQuorum": "majority",
+        },
+    )
+
+    expected = {
+        "code": 27,
+        "msg": (
+            f"Cannot find an index build on collection "
+            f"'{collection.database.name}.{collection.name}' "
+            f"with the provided index names"
+        ),
+    }
+    assertFailure(result, expected, msg="Should support setIndexCommitQuorum command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/setUserWriteBlockMode/test_smoke_setUserWriteBlockMode.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/setUserWriteBlockMode/test_smoke_setUserWriteBlockMode.py
@@ -1,0 +1,21 @@
+"""
+Smoke test for setUserWriteBlockMode command.
+
+Tests basic setUserWriteBlockMode functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_setUserWriteBlockMode(collection):
+    """Test basic setUserWriteBlockMode behavior."""
+    result = execute_admin_command(collection, {"setUserWriteBlockMode": 1, "global": False})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support setUserWriteBlockMode command")

--- a/documentdb_tests/compatibility/tests/system/administration/commands/shutdown/test_smoke_shutdown.py
+++ b/documentdb_tests/compatibility/tests/system/administration/commands/shutdown/test_smoke_shutdown.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for shutdown command.
+
+Tests basic shutdown functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertFailure
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_shutdown(collection):
+    """Test basic shutdown behavior."""
+    result = execute_admin_command(collection, {"shutdown": 1, "force": False, "timeoutSecs": 0.0})
+
+    expected = {"code": 13, "msg": "shutdown must run from localhost when running db without auth"}
+    assertFailure(result, expected, msg="Should support shutdown command")

--- a/documentdb_tests/compatibility/tests/system/diagnostic/commands/lockInfo/test_smoke_lockInfo.py
+++ b/documentdb_tests/compatibility/tests/system/diagnostic/commands/lockInfo/test_smoke_lockInfo.py
@@ -1,0 +1,20 @@
+"""
+Smoke test for lockInfo command.
+
+Tests basic lockInfo functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_admin_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_lockInfo(collection):
+    """Test basic lockInfo behavior."""
+    result = execute_admin_command(collection, {"lockInfo": 1})
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support lockInfo command")

--- a/documentdb_tests/compatibility/tests/system/security/authentication/commands/authenticate/test_smoke_authenticate.py
+++ b/documentdb_tests/compatibility/tests/system/security/authentication/commands/authenticate/test_smoke_authenticate.py
@@ -1,0 +1,25 @@
+"""
+Smoke test for authenticate command.
+
+Tests basic authenticate functionality.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import assertFailure
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+def test_smoke_authenticate(collection):
+    """Test basic authenticate behavior."""
+    # The authenticate command is deprecated but should be recognized
+    # We verify it's supported by checking it returns an auth error, not "command not found"
+    result = execute_command(
+        collection, {"authenticate": 1, "mechanism": "SCRAM-SHA-256", "user": "nonexistentuser"}
+    )
+
+    # Command is recognized and returns authentication error (not command not found)
+    expected = {"code": 18, "msg": "Authentication failed."}
+    assertFailure(result, expected, msg="Should support authenticate command")

--- a/documentdb_tests/compatibility/tests/system/security/encryption/test_smoke_encryption.py
+++ b/documentdb_tests/compatibility/tests/system/security/encryption/test_smoke_encryption.py
@@ -1,0 +1,32 @@
+"""
+Smoke test for encryption.
+
+Tests basic encryption functionality.
+"""
+
+from uuid import uuid4
+
+import pytest
+from bson.binary import Binary
+
+from documentdb_tests.framework.assertions import assertSuccessPartial
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.replica_set
+def test_smoke_encryption(collection):
+    """Test basic encryption behavior."""
+    result = execute_command(
+        collection,
+        {
+            "create": "encrypted_collection",
+            "encryptedFields": {
+                "fields": [{"path": "ssn", "bsonType": "string", "keyId": Binary(uuid4().bytes, 4)}]
+            },
+        },
+    )
+
+    expected = {"ok": 1.0}
+    assertSuccessPartial(result, expected, msg="Should support encryption")

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -179,7 +179,28 @@ def pytest_collection_modifyitems(session, config, items):
     'no_parallel' to prevent interference. Run these separately with:
         pytest -m no_parallel -p no:xdist
     Or run them manually with: pytest -m no_parallel -p no:xdist
+
+    Tests marked 'replica_set' are skipped when the server is not a replica set member.
     """
+    # Skip replica_set tests when not connected to a replica set
+    conn_str = getattr(config, "connection_string", "") or ""
+    try:
+        from pymongo import MongoClient
+
+        client = MongoClient(conn_str, serverSelectionTimeoutMS=5000, directConnection=True)
+        is_replica_set = bool(client.admin.command("hello").get("setName"))
+        client.close()
+    except Exception:
+        is_replica_set = False
+    if not is_replica_set:
+        for item in items:
+            if item.get_closest_marker("replica_set"):
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="requires replica set " "(server is not a replica set member)"
+                    )
+                )
+
     # Deselect no_parallel tests when running under xdist
     is_xdist = bool(getattr(config.option, "numprocesses", None)) or hasattr(config, "workerinput")
     if is_xdist:

--- a/documentdb_tests/pytest.ini
+++ b/documentdb_tests/pytest.ini
@@ -43,6 +43,7 @@ markers =
     replica: Tests that can only run on a replica
     engine_xfail(engine, reason, raises): expected failure for a specific engine
     no_parallel: Tests that must run sequentially (not in parallel)
+    replica_set: Tests that need to run on replica set
 
 # Timeout for tests (seconds)
 timeout = 300


### PR DESCRIPTION
## Summary

Add 79 new smoke tests (batch 5) covering features not included in previous batches:

- **Change Streams** (16): create, insert, update, delete, drop, rename, replace, modify, invalidate, dropDatabase, dropIndexes, createIndexes, refineCollectionShardKey, reshardCollection, shardCollection
- **Collections & Data Types** (10): collation, capped, clustered, views, materialized-views, timeseries, validateDBMetadata, tailable-cursors, bson-types, mongodb-extended-json
- **Index Properties** (6): case-insensitive, hidden, partial, sparse, ttl, unique
- **Index Types** (7): compound, geospatial, hashed, multikey, single, text, wildcard
- **Expressions** (7): literal, let, function, operator_accumulator, toHashedIndexKey, text/meta, concatArrays
- **Stages** (11): search, searchMeta, vectorSearch, rankFusion, listSessions, listSearchIndexes, listClusterCatalog, listSampledQueries, querySettings, queryStats, changeStreamSplitLargeEvent
- **System Stages** (4): changeStream, currentOp, documents, listLocalSessions
- **Sessions** (3): abortTransaction, commitTransaction, startSession
- **Query** (1): text
- **Query-and-Write** (2): read-concern, write-concern
- **Query Planning** (2): removeQuerySettings, setQuerySettings
- **Administration** (7): fsyncUnlock, shutdown, compactStructuredEncryptionData, setIndexCommitQuorum, getDefaultRWConcern, setDefaultRWConcern, setUserWriteBlockMode
- **Diagnostic** (1): lockInfo
- **Security** (3): logApplicationMessage, authenticate, encryption

## Other changes

- Add `replica_set` marker for tests requiring replica set topology (24 tests). Skipped by default; can be run locally with a replica set endpoint.
- Add `no_parallel` marker to fsyncUnlock test (locks server with fsync).
- Add `docs/SMOKE_TEST_NOTE.md` documenting missing features, skipped tests, replica set test errors, and assert-on-failure tests.
- Update README with `replica_set` marker in Special Tags section.

## Test results

- Lint: all passed (black, isort, flake8, mypy)
- Unit tests: 20 passed
- Compatibility tests: 9600 passed, 29 skipped, 21 xfailed

Closes #61