### PR TITLE
Avoid parallel scope issues for validateDBMetadata tests

### DIFF
--- a/documentdb_tests/compatibility/tests/core/collections/commands/validateDBMetadata/test_validateDBMetadata_max_time_ms.py
+++ b/documentdb_tests/compatibility/tests/core/collections/commands/validateDBMetadata/test_validateDBMetadata_max_time_ms.py
@@ -50,6 +50,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": 0,
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -60,6 +62,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": INT32_MAX,
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -70,6 +74,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": Int64(1000),
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -80,6 +86,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": 500.0,
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -90,6 +98,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": Decimal128("100"),
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -100,6 +110,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": DOUBLE_NEGATIVE_ZERO,
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -110,6 +122,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": DECIMAL128_NEGATIVE_ZERO,
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -120,6 +134,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": Decimal128("1000.0"),
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -130,6 +146,8 @@ VALIDATE_DB_METADATA_MAX_TIME_MS_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "maxTimeMS": Decimal128("5000.00"),
         },
         expected={"ok": 1.0, "apiVersionErrors": []},

--- a/documentdb_tests/compatibility/tests/core/collections/commands/validateDBMetadata/test_validateDBMetadata_read_write_concern.py
+++ b/documentdb_tests/compatibility/tests/core/collections/commands/validateDBMetadata/test_validateDBMetadata_read_write_concern.py
@@ -28,6 +28,8 @@ VALIDATE_DB_METADATA_READ_CONCERN_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "readConcern": {"level": "local"},
         },
         expected={"ok": 1.0, "apiVersionErrors": []},
@@ -38,6 +40,8 @@ VALIDATE_DB_METADATA_READ_CONCERN_ACCEPTANCE_TESTS: list[CommandTestCase] = [
         command=lambda ctx: {
             "validateDBMetadata": 1,
             "apiParameters": {"version": "1", "strict": True},
+            "db": ctx.database,
+            "collection": ctx.collection,
             "readConcern": {},
         },
         expected={"ok": 1.0, "apiVersionErrors": []},


### PR DESCRIPTION
This changes scopes the `validateDBMetadata` tests to their own db/collection to prevent flaky failures from parallel tests like in #217.

The `maxTimeMS` and `readConcern` tests ran unscoped `validateDBMetadata` commands, which could pick up API-incompatible indexes created by other parallel workers. I added scopes to these given doing so doesn't affect what is being tested, which is also consistent with all other `validateDBMetadata` tests.