### PR TITLE
Add behavior tests for $mul, $rename, $ positional, $[] positional-all

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/update/array/positional-all/test_positional-all_behaviors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/update/array/positional-all/test_positional-all_behaviors.py
@@ -1,0 +1,234 @@
+"""
+Comprehensive tests for $[] (positional all) update operator.
+
+Covers basic array updates, nested doc arrays, empty arrays, missing fields,
+non-array fields, multi-document updates, upsert, command paths, and
+composition conflicts.
+
+Oracle: MongoDB 7.0.
+SUT-agnostic: assertions follow observed MongoDB behavior; engine divergences
+are tracked via `engine_xfail` markers with tracking links.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import (
+    assertFailureCode,
+    assertSuccess,
+    assertSuccessPartial,
+)
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.update
+
+
+# ---- happy path: basic $[] ---------------------------------------------------
+
+
+def test_positional_all_multiplies_all_elements(collection):
+    """$[] with $mul updates every element in the array."""
+    collection.insert_one({"_id": 1, "items": [1, 2, 3, 4]})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$mul": {"items.$[]": 10}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "items": [10, 20, 30, 40]}])
+
+
+def test_positional_all_sets_nested_field_in_all_elements(collection):
+    """$[] with $set updates a sub-field in every array element."""
+    collection.insert_one({"_id": 1, "items": [{"v": 1}, {"v": 2}, {"v": 3}]})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"items.$[].v": 0}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "items": [{"v": 0}, {"v": 0}, {"v": 0}]}])
+
+
+def test_positional_all_replaces_nested_arrays(collection):
+    """$[] replaces each sub-array element entirely."""
+    collection.insert_one({"_id": 1, "a": [[1, 2], [3, 4]]})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"a.$[]": [99]}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "a": [[99], [99]]}])
+
+
+def test_positional_all_inc_all_elements(collection):
+    """$[] with $inc increments every element in the array."""
+    collection.insert_one({"_id": 1, "scores": [10, 20, 30]})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$inc": {"scores.$[]": 5}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "scores": [15, 25, 35]}])
+
+
+# ---- empty array (no-op) ----------------------------------------------------
+
+
+@pytest.mark.engine_xfail(
+    engine="pgmongo",
+    reason="pgmongo returns nModified=1 and inserts None into empty array; tracked: **NEEDS ADO ITEM**",
+    raises=AssertionError,
+)
+def test_positional_all_on_empty_array_is_noop(collection):
+    """$[] on an empty array is a no-op (nModified=0, array unchanged)."""
+    collection.insert_one({"_id": 1, "items": []})
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"items.$[].v": 99}}}],
+        },
+    )
+    assertSuccessPartial(result, {"n": 1, "nModified": 0, "ok": 1.0})
+
+
+# ---- multi -------------------------------------------------------------------
+
+
+def test_positional_all_multi_updates_all_docs(collection):
+    """$[] with multi:true updates all elements across all matched documents."""
+    collection.insert_many([
+        {"_id": 1, "scores": [10, 20]},
+        {"_id": 2, "scores": [30, 40]},
+    ])
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {}, "u": {"$inc": {"scores.$[]": 1}}, "multi": True}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "scores": [11, 21]}, {"_id": 2, "scores": [31, 41]}])
+
+
+# ---- command paths -----------------------------------------------------------
+
+
+def test_positional_all_via_find_and_modify(collection):
+    """$[] works through findAndModify and returns the updated document."""
+    collection.insert_one({"_id": 1, "arr": [10, 20, 30]})
+    result = execute_command(
+        collection,
+        {
+            "findAndModify": collection.name,
+            "query": {"_id": 1},
+            "update": {"$inc": {"arr.$[]": 5}},
+            "new": True,
+        },
+    )
+    assertSuccessPartial(result, {"value": {"_id": 1, "arr": [15, 25, 35]}})
+
+
+# ---- composition -------------------------------------------------------------
+
+
+def test_positional_all_composes_with_set_on_different_path(collection):
+    """$[] and $set on a different field both apply cleanly."""
+    collection.insert_one({"_id": 1, "items": [1, 2, 3], "status": "old"})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {"q": {"_id": 1}, "u": {"$inc": {"items.$[]": 10}, "$set": {"status": "new"}}}
+            ],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "items": [11, 12, 13], "status": "new"}])
+
+
+# ---- error cases -------------------------------------------------------------
+
+
+def test_positional_all_on_missing_field_fails(collection):
+    """$[] on a path that does not exist in the document fails with code 2."""
+    collection.insert_one({"_id": 1, "other": "x"})
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"items.$[].v": 99}}}],
+        },
+    )
+    assertFailureCode(result, 2)
+
+
+@pytest.mark.engine_xfail(
+    engine="pgmongo",
+    reason="pgmongo returns error code 28 instead of 2 for non-array field; tracked: **NEEDS ADO ITEM**",
+    raises=AssertionError,
+)
+def test_positional_all_on_non_array_field_fails(collection):
+    """$[] on a non-array field fails with BadValue (code 2)."""
+    collection.insert_one({"_id": 1, "items": "not_an_array"})
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"items.$[].v": 99}}}],
+        },
+    )
+    assertFailureCode(result, 2)
+
+
+def test_positional_all_upsert_on_missing_doc_fails(collection):
+    """$[] with upsert fails because the path must exist in the document."""
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {"q": {"_id": 99}, "u": {"$set": {"items.$[].v": 1}}, "upsert": True}
+            ],
+        },
+    )
+    assertFailureCode(result, 2)
+
+
+def test_positional_all_conflicts_with_same_path(collection):
+    """$set + $inc on the same $[] path produces conflict (code 40)."""
+    collection.insert_one({"_id": 1, "arr": [1, 2]})
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {"q": {"_id": 1}, "u": {"$set": {"arr.$[]": 0}, "$inc": {"arr.$[]": 1}}}
+            ],
+        },
+    )
+    assertFailureCode(result, 40)

--- a/documentdb_tests/compatibility/tests/core/operator/update/array/positional/test_positional_behaviors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/update/array/positional/test_positional_behaviors.py
@@ -1,0 +1,208 @@
+"""
+Comprehensive tests for $ (positional) update operator.
+
+Covers basic array element matching, scalar arrays, $elemMatch queries,
+nested arrays, multi-document updates, error conditions, and command paths.
+
+Oracle: MongoDB 7.0.
+SUT-agnostic: assertions follow observed MongoDB behavior; engine divergences
+are tracked via `engine_xfail` markers with tracking links.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import (
+    assertFailureCode,
+    assertSuccess,
+    assertSuccessPartial,
+)
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.update
+
+
+# ---- happy path: basic positional update -------------------------------------
+
+
+def test_positional_updates_matched_array_element(collection):
+    """$ updates the first array element matched by the query condition."""
+    collection.insert_one(
+        {"_id": 1, "items": [{"name": "A", "v": 10}, {"name": "B", "v": 20}]}
+    )
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {"q": {"_id": 1, "items.name": "B"}, "u": {"$set": {"items.$.v": 99}}}
+            ],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "items": [{"name": "A", "v": 10}, {"name": "B", "v": 99}]}])
+
+
+def test_positional_with_inc_on_scalar_array(collection):
+    """$ with $inc updates the matched scalar array element."""
+    collection.insert_one({"_id": 1, "scores": [10, 20, 30]})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1, "scores": 20}, "u": {"$inc": {"scores.$": 5}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "scores": [10, 25, 30]}])
+
+
+def test_positional_with_elemmatch_query(collection):
+    """$ works with $elemMatch to target a specific sub-document."""
+    collection.insert_one(
+        {"_id": 1, "items": [{"x": 1, "y": 2}, {"x": 3, "y": 4}]}
+    )
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {
+                    "q": {"_id": 1, "items": {"$elemMatch": {"x": 3}}},
+                    "u": {"$set": {"items.$.y": 99}},
+                }
+            ],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "items": [{"x": 1, "y": 2}, {"x": 3, "y": 99}]}])
+
+
+# ---- nested arrays -----------------------------------------------------------
+
+
+@pytest.mark.engine_xfail(
+    engine="pgmongo",
+    reason="positional $ matches wrong element when query targets nested array value",
+)
+def test_positional_with_nested_array_field(collection):
+    """$ on a nested array replaces the matched element's sub-field."""
+    collection.insert_one({"_id": 1, "a": [{"b": [1, 2]}, {"b": [3, 4]}]})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1, "a.b": 3}, "u": {"$set": {"a.$.b": [30, 40]}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "a": [{"b": [1, 2]}, {"b": [30, 40]}]}])
+
+
+# ---- multi -------------------------------------------------------------------
+
+
+def test_positional_multi_updates_first_match_per_doc(collection):
+    """$ with multi:true updates the first matched element in each document."""
+    collection.insert_many([
+        {"_id": 1, "items": [{"v": 5}, {"v": 10}]},
+        {"_id": 2, "items": [{"v": 15}, {"v": 10}]},
+    ])
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {"q": {"items.v": 10}, "u": {"$set": {"items.$.v": 0}}, "multi": True}
+            ],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {}, "sort": {"_id": 1}}
+    )
+    assertSuccess(
+        result,
+        [
+            {"_id": 1, "items": [{"v": 5}, {"v": 0}]},
+            {"_id": 2, "items": [{"v": 15}, {"v": 0}]},
+        ],
+    )
+
+
+# ---- command paths -----------------------------------------------------------
+
+
+def test_positional_via_find_and_modify(collection):
+    """$ works through findAndModify."""
+    collection.insert_one({"_id": 1, "arr": [{"k": "a", "v": 1}, {"k": "b", "v": 2}]})
+    result = execute_command(
+        collection,
+        {
+            "findAndModify": collection.name,
+            "query": {"arr.k": "b"},
+            "update": {"$set": {"arr.$.v": 99}},
+            "new": True,
+        },
+    )
+    assertSuccessPartial(result, {"value": {"_id": 1, "arr": [{"k": "a", "v": 1}, {"k": "b", "v": 99}]}})
+
+
+# ---- composition -------------------------------------------------------------
+
+
+def test_positional_composes_with_set_on_different_path(collection):
+    """$ and $set on a different field both apply cleanly."""
+    collection.insert_one({"_id": 1, "items": [{"v": 10}, {"v": 20}], "status": "old"})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {
+                    "q": {"_id": 1, "items.v": 20},
+                    "u": {"$set": {"items.$.v": 99, "status": "new"}},
+                }
+            ],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "items": [{"v": 10}, {"v": 99}], "status": "new"}])
+
+
+# ---- error cases -------------------------------------------------------------
+
+
+def test_positional_without_array_query_fails(collection):
+    """$ without an array query condition fails with BadValue (code 2)."""
+    collection.insert_one({"_id": 1, "items": [1, 2, 3]})
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$set": {"items.$.v": 99}}}],
+        },
+    )
+    assertFailureCode(result, 2)
+
+
+def test_positional_upsert_without_match_fails(collection):
+    """$ with upsert on a non-existing doc fails (no array match possible)."""
+    result = execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [
+                {"q": {"items.v": 5}, "u": {"$set": {"items.$.v": 99}}, "upsert": True}
+            ],
+        },
+    )
+    assertFailureCode(result, 2)

--- a/documentdb_tests/compatibility/tests/core/operator/update/fields/mul/test_mul_behaviors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/update/fields/mul/test_mul_behaviors.py
@@ -1,0 +1,300 @@
+"""
+Comprehensive tests for $mul update operator.
+
+Covers type coercion, missing fields, boundary values, nested paths,
+command paths (update, findAndModify), multi-document updates, upsert,
+composition, and error cases.
+
+Oracle: MongoDB 7.0.
+SUT-agnostic: assertions follow observed MongoDB behavior; engine divergences
+are tracked via `engine_xfail` markers with tracking links.
+"""
+
+import pytest
+from bson import Decimal128, Int64
+
+from documentdb_tests.framework.assertions import (
+    assertFailureCode,
+    assertSuccess,
+    assertSuccessPartial,
+)
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.update
+
+
+# ---- happy path: type matrix ------------------------------------------------
+
+
+def test_mul_int32_times_int32(collection):
+    """$mul with int32 * int32 produces int32 result."""
+    collection.insert_one({"_id": 1, "v": 10})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 3}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": 30}])
+
+
+def test_mul_int64_times_int64(collection):
+    """$mul with Int64 * Int64 produces Int64 result."""
+    collection.insert_one({"_id": 1, "v": Int64(100)})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": Int64(3)}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": Int64(300)}])
+
+
+def test_mul_double_times_double(collection):
+    """$mul with double * double produces double result."""
+    collection.insert_one({"_id": 1, "v": 2.5})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 2.0}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": 5.0}])
+
+
+def test_mul_int64_times_double_promotes_to_double(collection):
+    """$mul with Int64 * double promotes result to double."""
+    collection.insert_one({"_id": 1, "v": Int64(10)})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 2.5}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": 25.0}])
+
+
+def test_mul_int32_times_int64_promotes_to_int64(collection):
+    """$mul with int32 * Int64 promotes result to Int64."""
+    collection.insert_one({"_id": 1, "v": 10})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": Int64(3)}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": Int64(30)}])
+
+
+def test_mul_decimal128_times_int(collection):
+    """$mul with Decimal128 * int produces Decimal128 result."""
+    collection.insert_one({"_id": 1, "v": Decimal128("10.5")})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 2}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": Decimal128("21.0")}])
+
+
+# ---- boundary values ---------------------------------------------------------
+
+
+def test_mul_by_zero_returns_zero(collection):
+    """$mul by 0 sets the field to 0."""
+    collection.insert_one({"_id": 1, "v": 42})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 0}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": 0}])
+
+
+def test_mul_by_one_is_noop(collection):
+    """$mul by 1 does not modify the value (nModified=0)."""
+    collection.insert_one({"_id": 1, "v": 7})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 1}}}]},
+    )
+    assertSuccessPartial(result, {"n": 1, "nModified": 0, "ok": 1.0})
+
+
+def test_mul_negative_multiplier(collection):
+    """$mul with a negative multiplier negates the value."""
+    collection.insert_one({"_id": 1, "v": 10})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": -3}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": -30}])
+
+
+# ---- missing field and implicit creation -------------------------------------
+
+
+def test_mul_on_missing_field_creates_zero(collection):
+    """$mul on a missing field creates it with value 0."""
+    collection.insert_one({"_id": 1, "other": "x"})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 3}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "other": "x", "v": 0}])
+
+
+def test_mul_on_missing_field_int64_creates_int64_zero(collection):
+    """$mul missing field with Int64 multiplier creates Int64(0)."""
+    collection.insert_one({"_id": 1, "other": "x"})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": Int64(5)}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "other": "x", "v": Int64(0)}])
+
+
+# ---- nested path -------------------------------------------------------------
+
+
+def test_mul_nested_dotted_path(collection):
+    """$mul works on dotted nested paths."""
+    collection.insert_one({"_id": 1, "a": {"b": 5}})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"a.b": 3}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "a": {"b": 15}}])
+
+
+# ---- command paths -----------------------------------------------------------
+
+
+def test_mul_via_find_and_modify(collection):
+    """$mul works through findAndModify and returns the updated document."""
+    collection.insert_one({"_id": 1, "v": 7})
+    result = execute_command(
+        collection,
+        {"findAndModify": collection.name, "query": {"_id": 1}, "update": {"$mul": {"v": 3}}, "new": True},
+    )
+    assertSuccessPartial(result, {"value": {"_id": 1, "v": 21}})
+
+
+# ---- multi and upsert --------------------------------------------------------
+
+
+def test_mul_multi_true_updates_all_matched(collection):
+    """$mul with multi:true multiplies across all matched documents."""
+    collection.insert_many([{"_id": i, "v": i * 10} for i in range(1, 4)])
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {}, "u": {"$mul": {"v": 2}}, "multi": True}]},
+    )
+    assertSuccessPartial(result, {"n": 3, "nModified": 3, "ok": 1.0})
+
+
+def test_mul_multi_true_result_values(collection):
+    """$mul with multi:true produces correct values in all docs."""
+    collection.insert_many([{"_id": 1, "v": 10}, {"_id": 2, "v": 20}, {"_id": 3, "v": 30}])
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {}, "u": {"$mul": {"v": 2}}, "multi": True}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": 20}, {"_id": 2, "v": 40}, {"_id": 3, "v": 60}])
+
+
+def test_mul_upsert_creates_doc_with_zero(collection):
+    """$mul with upsert on non-existing doc creates it with the field set to 0."""
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 99}, "u": {"$mul": {"v": 5}}, "upsert": True}]},
+    )
+    assertSuccessPartial(result, {"n": 1, "nModified": 0, "ok": 1.0})
+
+
+def test_mul_upsert_doc_value(collection):
+    """$mul with upsert produces a document with field value 0."""
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 99}, "u": {"$mul": {"v": 5}}, "upsert": True}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 99}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 99, "v": 0}])
+
+
+# ---- composition -------------------------------------------------------------
+
+
+def test_mul_composes_with_set_on_different_paths(collection):
+    """$mul and $set on different fields both apply cleanly."""
+    collection.insert_one({"_id": 1, "v": 5, "name": "old"})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 3}, "$set": {"name": "new"}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "v": 15, "name": "new"}])
+
+
+# ---- error cases -------------------------------------------------------------
+
+
+def test_mul_rejects_string_multiplier(collection):
+    """$mul with a non-numeric multiplier fails with code 14 (TypeMismatch)."""
+    collection.insert_one({"_id": 1, "v": 10})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": "abc"}}}]},
+    )
+    assertFailureCode(result, 14)
+
+
+def test_mul_rejects_non_numeric_field_value(collection):
+    """$mul on a field with a non-numeric value fails with code 14."""
+    collection.insert_one({"_id": 1, "v": "hello"})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 2}}}]},
+    )
+    assertFailureCode(result, 14)
+
+
+def test_mul_conflicts_with_set_on_same_path(collection):
+    """$mul + $set on the same path produces ConflictingUpdateOperators (code 40)."""
+    collection.insert_one({"_id": 1, "v": 10})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$mul": {"v": 2}, "$set": {"v": 100}}}]},
+    )
+    assertFailureCode(result, 40)

--- a/documentdb_tests/compatibility/tests/core/operator/update/fields/rename/test_rename_behaviors.py
+++ b/documentdb_tests/compatibility/tests/core/operator/update/fields/rename/test_rename_behaviors.py
@@ -1,0 +1,232 @@
+"""
+Comprehensive tests for $rename update operator.
+
+Covers basic renames, nested paths, missing fields, error conditions,
+command paths (update, findAndModify), multi-document updates, upsert,
+and composition conflicts.
+
+Oracle: MongoDB 7.0.
+SUT-agnostic: assertions follow observed MongoDB behavior; engine divergences
+are tracked via `engine_xfail` markers with tracking links.
+"""
+
+import pytest
+
+from documentdb_tests.framework.assertions import (
+    assertFailureCode,
+    assertSuccess,
+    assertSuccessPartial,
+)
+from documentdb_tests.framework.executor import execute_command
+
+pytestmark = pytest.mark.update
+
+
+# ---- happy path: basic rename ------------------------------------------------
+
+
+def test_rename_basic_top_level_field(collection):
+    """$rename moves a top-level field to a new name."""
+    collection.insert_one({"_id": 1, "a": 10, "b": 20})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"a": "c"}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "b": 20, "c": 10}])
+
+
+def test_rename_overwrites_existing_destination(collection):
+    """$rename to an existing field name overwrites the destination."""
+    collection.insert_one({"_id": 1, "src": 42, "dst": "old"})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"src": "dst"}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "dst": 42}])
+
+
+# ---- missing field (no-op) ---------------------------------------------------
+
+
+def test_rename_missing_source_is_noop(collection):
+    """$rename on a non-existent source field is a no-op (nModified=0)."""
+    collection.insert_one({"_id": 1, "x": 1})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"nonexist": "y"}}}]},
+    )
+    assertSuccessPartial(result, {"n": 1, "nModified": 0, "ok": 1.0})
+
+
+# ---- nested paths ------------------------------------------------------------
+
+
+def test_rename_nested_field_within_same_parent(collection):
+    """$rename moves a nested field to another key under the same parent."""
+    collection.insert_one({"_id": 1, "a": {"b": 5, "c": 6}})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"a.b": "a.d"}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "a": {"c": 6, "d": 5}}])
+
+
+def test_rename_top_level_to_nested_destination(collection):
+    """$rename can move a top-level field into a nested path, creating intermediates."""
+    collection.insert_one({"_id": 1, "x": 99})
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"x": "a.b"}}}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "a": {"b": 99}}])
+
+
+# ---- command paths -----------------------------------------------------------
+
+
+def test_rename_via_find_and_modify(collection):
+    """$rename works through findAndModify and returns the updated document."""
+    collection.insert_one({"_id": 1, "x": 42})
+    result = execute_command(
+        collection,
+        {"findAndModify": collection.name, "query": {"_id": 1}, "update": {"$rename": {"x": "y"}}, "new": True},
+    )
+    assertSuccessPartial(result, {"value": {"_id": 1, "y": 42}})
+
+
+# ---- multi and upsert --------------------------------------------------------
+
+
+def test_rename_multi_true_renames_across_documents(collection):
+    """$rename with multi:true applies to all matched documents."""
+    collection.insert_many([
+        {"_id": 1, "old": "a"},
+        {"_id": 2, "old": "b"},
+        {"_id": 3, "old": "c"},
+    ])
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {}, "u": {"$rename": {"old": "new"}}, "multi": True}]},
+    )
+    assertSuccessPartial(result, {"n": 3, "nModified": 3, "ok": 1.0})
+
+
+def test_rename_multi_true_result_values(collection):
+    """$rename with multi:true produces correct documents."""
+    collection.insert_many([
+        {"_id": 1, "old": "a"},
+        {"_id": 2, "old": "b"},
+    ])
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {}, "u": {"$rename": {"old": "new"}}, "multi": True}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "new": "a"}, {"_id": 2, "new": "b"}])
+
+
+def test_rename_upsert_creates_doc_without_renamed_field(collection):
+    """$rename with upsert on missing doc creates doc without the renamed field."""
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 50}, "u": {"$rename": {"a": "b"}}, "upsert": True}]},
+    )
+    assertSuccessPartial(result, {"n": 1, "nModified": 0, "ok": 1.0})
+
+
+def test_rename_upsert_doc_contents(collection):
+    """$rename with upsert produces a doc with only _id (source missing)."""
+    execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 50}, "u": {"$rename": {"a": "b"}}, "upsert": True}]},
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 50}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 50}])
+
+
+# ---- composition -------------------------------------------------------------
+
+
+def test_rename_composes_with_set_on_different_paths(collection):
+    """$rename and $set on different fields both apply cleanly."""
+    collection.insert_one({"_id": 1, "a": 10, "c": "keep"})
+    execute_command(
+        collection,
+        {
+            "update": collection.name,
+            "updates": [{"q": {"_id": 1}, "u": {"$rename": {"a": "b"}, "$set": {"c": "updated"}}}],
+        },
+    )
+    result = execute_command(
+        collection, {"find": collection.name, "filter": {"_id": 1}, "sort": {"_id": 1}}
+    )
+    assertSuccess(result, [{"_id": 1, "b": 10, "c": "updated"}])
+
+
+# ---- error cases -------------------------------------------------------------
+
+
+def test_rename_id_field_fails(collection):
+    """$rename from _id fails with ImmutableField (code 66)."""
+    collection.insert_one({"_id": 1, "a": 10})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"_id": "newid"}}}]},
+    )
+    assertFailureCode(result, 66)
+
+
+def test_rename_to_id_field_fails(collection):
+    """$rename to _id fails with ImmutableField (code 66)."""
+    collection.insert_one({"_id": 1, "a": 10})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"a": "_id"}}}]},
+    )
+    assertFailureCode(result, 66)
+
+
+def test_rename_non_string_destination_fails(collection):
+    """$rename with a non-string destination value fails with BadValue (code 2)."""
+    collection.insert_one({"_id": 1, "a": 10})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"a": 123}}}]},
+    )
+    assertFailureCode(result, 2)
+
+
+def test_rename_to_empty_string_fails(collection):
+    """$rename to an empty string path fails with EmptyFieldName (code 56)."""
+    collection.insert_one({"_id": 1, "a": 10})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"a": ""}}}]},
+    )
+    assertFailureCode(result, 56)
+
+
+def test_rename_conflicts_with_set_on_same_source_path(collection):
+    """$rename + $set on the same source path produces conflict (code 40)."""
+    collection.insert_one({"_id": 1, "a": 10, "b": 20})
+    result = execute_command(
+        collection,
+        {"update": collection.name, "updates": [{"q": {"_id": 1}, "u": {"$rename": {"b": "z"}, "$set": {"b": 100}}}]},
+    )
+    assertFailureCode(result, 40)


### PR DESCRIPTION
Comprehensive compat-functional tests covering type coercion, boundary values, nested paths, command paths (update, findAndModify), multi-doc updates, upsert, composition, and error cases.