### PR TITLE
Feature: query-and-write delete command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Functional tests require a running database instance:
 pytest --connection-string mongodb://localhost:27017 --engine-name documentdb
 
 # Run a specific test file
-pytest documentdb_tests/compatibility/tests/core/query-and-write/commands/find/test_find_basic_queries.py
+pytest documentdb_tests/compatibility/tests/core/query_and_write/commands/find/test_find_basic_queries.py
 
 # Run tests by marker
 pytest -m find

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
@@ -113,7 +113,9 @@ def test_delete_ordered_true_stops_on_error(collection):
         result,
         {
             "n": Eq(1),
-            "writeErrors": [Len(1), Eq([{"index": 1, "code": BAD_VALUE_ERROR}])],
+            "writeErrors": Len(1),
+            "writeErrors.0.index": Eq(1),
+            "writeErrors.0.code": Eq(BAD_VALUE_ERROR),
         },
         msg="delete ordered:true should stop at first error with exactly one writeError",
         raw_res=True,
@@ -139,7 +141,9 @@ def test_delete_ordered_false_continues_on_error(collection):
         result,
         {
             "n": Eq(2),
-            "writeErrors": [Len(1), Eq([{"index": 1, "code": BAD_VALUE_ERROR}])],
+            "writeErrors": Len(1),
+            "writeErrors.0.index": Eq(1),
+            "writeErrors.0.code": Eq(BAD_VALUE_ERROR),
         },
         msg="delete ordered:false should continue past errors and report exactly one writeError",
         raw_res=True,
@@ -164,7 +168,9 @@ def test_delete_ordered_true_error_at_first(collection):
         result,
         {
             "n": Eq(0),
-            "writeErrors": [Len(1), Eq([{"index": 0, "code": BAD_VALUE_ERROR}])],
+            "writeErrors": Len(1),
+            "writeErrors.0.index": Eq(0),
+            "writeErrors.0.code": Eq(BAD_VALUE_ERROR),
         },
         msg="delete ordered:true should stop on first error with exactly one writeError",
         raw_res=True,
@@ -189,7 +195,9 @@ def test_delete_ordered_false_error_at_first(collection):
         result,
         {
             "n": Eq(1),
-            "writeErrors": [Len(1), Eq([{"index": 0, "code": BAD_VALUE_ERROR}])],
+            "writeErrors": Len(1),
+            "writeErrors.0.index": Eq(0),
+            "writeErrors.0.code": Eq(BAD_VALUE_ERROR),
         },
         msg="delete ordered:false should continue past errors and report exactly one writeError",
         raw_res=True,

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
@@ -11,10 +11,14 @@ from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )
-from documentdb_tests.framework.assertions import assertResult, assertSuccessPartial
+from documentdb_tests.framework.assertions import (
+    assertProperties,
+    assertResult,
+)
 from documentdb_tests.framework.error_codes import BAD_VALUE_ERROR
 from documentdb_tests.framework.executor import execute_command
 from documentdb_tests.framework.parametrize import pytest_params
+from documentdb_tests.framework.property_checks import Eq, Len
 
 # Property [Bulk Summation]: n equals the sum of deletions across all statements.
 BULK_TESTS: list[CommandTestCase] = [
@@ -45,7 +49,7 @@ BULK_TESTS: list[CommandTestCase] = [
         msg="delete should handle mixed limit:0 and limit:1 in bulk",
     ),
     CommandTestCase(
-        "duplicate_target_ordered",
+        "duplicate_target_no_double_count",
         docs=[{"_id": 1}, {"_id": 2}],
         command=lambda ctx: {
             "delete": ctx.collection,
@@ -105,10 +109,14 @@ def test_delete_ordered_true_stops_on_error(collection):
             "ordered": True,
         },
     )
-    assertSuccessPartial(
+    assertProperties(
         result,
-        {"ok": 1.0, "n": 1, "writeErrors": [{"index": 1, "code": BAD_VALUE_ERROR}]},
-        msg="delete ordered:true should stop at first error",
+        {
+            "n": Eq(1),
+            "writeErrors": [Len(1), Eq([{"index": 1, "code": BAD_VALUE_ERROR}])],
+        },
+        msg="delete ordered:true should stop at first error with exactly one writeError",
+        raw_res=True,
     )
 
 
@@ -127,10 +135,14 @@ def test_delete_ordered_false_continues_on_error(collection):
             "ordered": False,
         },
     )
-    assertSuccessPartial(
+    assertProperties(
         result,
-        {"ok": 1.0, "n": 2, "writeErrors": [{"index": 1, "code": BAD_VALUE_ERROR}]},
-        msg="delete ordered:false should continue past errors",
+        {
+            "n": Eq(2),
+            "writeErrors": [Len(1), Eq([{"index": 1, "code": BAD_VALUE_ERROR}])],
+        },
+        msg="delete ordered:false should continue past errors and report exactly one writeError",
+        raw_res=True,
     )
 
 
@@ -148,10 +160,14 @@ def test_delete_ordered_true_error_at_first(collection):
             "ordered": True,
         },
     )
-    assertSuccessPartial(
+    assertProperties(
         result,
-        {"ok": 1.0, "n": 0, "writeErrors": [{"index": 0, "code": BAD_VALUE_ERROR}]},
-        msg="delete ordered:true should stop immediately on first error",
+        {
+            "n": Eq(0),
+            "writeErrors": [Len(1), Eq([{"index": 0, "code": BAD_VALUE_ERROR}])],
+        },
+        msg="delete ordered:true should stop on first error with exactly one writeError",
+        raw_res=True,
     )
 
 
@@ -169,8 +185,12 @@ def test_delete_ordered_false_error_at_first(collection):
             "ordered": False,
         },
     )
-    assertSuccessPartial(
+    assertProperties(
         result,
-        {"ok": 1.0, "n": 1, "writeErrors": [{"index": 0, "code": BAD_VALUE_ERROR}]},
-        msg="delete ordered:false should execute subsequent statements",
+        {
+            "n": Eq(1),
+            "writeErrors": [Len(1), Eq([{"index": 0, "code": BAD_VALUE_ERROR}])],
+        },
+        msg="delete ordered:false should continue past errors and report exactly one writeError",
+        raw_res=True,
     )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
@@ -1,0 +1,176 @@
+"""Delete command bulk operations and ordered behavior.
+
+Tests multiple delete statements, ordered vs unordered error handling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+    CommandContext,
+    CommandTestCase,
+)
+from documentdb_tests.framework.assertions import assertResult, assertSuccessPartial
+from documentdb_tests.framework.error_codes import BAD_VALUE_ERROR
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+
+# Property [Bulk Summation]: n equals the sum of deletions across all statements.
+BULK_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "multiple_statements_sum_n",
+        docs=[{"_id": i, "a": i} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [
+                {"q": {"_id": 1}, "limit": 1},
+                {"q": {"_id": 2}, "limit": 1},
+            ],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should sum n across multiple statements",
+    ),
+    CommandTestCase(
+        "mixed_limits",
+        docs=[{"_id": i, "status": "D" if i < 3 else "A"} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [
+                {"q": {"status": "D"}, "limit": 0},
+                {"q": {"status": "A"}, "limit": 1},
+            ],
+        },
+        expected={"ok": 1.0, "n": 4},
+        msg="delete should handle mixed limit:0 and limit:1 in bulk",
+    ),
+    CommandTestCase(
+        "duplicate_target_ordered",
+        docs=[{"_id": 1}, {"_id": 2}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [
+                {"q": {"_id": 1}, "limit": 1},
+                {"q": {"_id": 1}, "limit": 1},
+                {"q": {"_id": 2}, "limit": 1},
+            ],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should not count already-deleted document twice",
+    ),
+    CommandTestCase(
+        "first_removes_docs_second_would_match",
+        docs=[{"_id": i, "status": "D"} for i in range(3)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "ordered": True,
+            "deletes": [
+                {"q": {"status": "D"}, "limit": 0},
+                {"q": {"status": "D"}, "limit": 0},
+            ],
+        },
+        expected={"ok": 1.0, "n": 3},
+        msg="delete second statement should find nothing after first removed all",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", pytest_params(BULK_TESTS))
+def test_delete_bulk_operations(database_client, collection, test):
+    """Test delete command bulk operations."""
+    collection = test.prepare(database_client, collection)
+    ctx = CommandContext.from_collection(collection)
+    result = execute_command(collection, test.build_command(ctx))
+    assertResult(
+        result,
+        expected=test.build_expected(ctx),
+        error_code=test.error_code,
+        msg=test.msg,
+        raw_res=True,
+    )
+
+
+def test_delete_ordered_true_stops_on_error(collection):
+    """Test delete ordered:true stops execution after first error."""
+    collection.insert_many([{"_id": i, "a": i} for i in range(5)])
+    result = execute_command(
+        collection,
+        {
+            "delete": collection.name,
+            "deletes": [
+                {"q": {"_id": 1}, "limit": 1},
+                {"q": {"$invalid": 1}, "limit": 1},
+                {"q": {"_id": 3}, "limit": 1},
+            ],
+            "ordered": True,
+        },
+    )
+    assertSuccessPartial(
+        result,
+        {"ok": 1.0, "n": 1, "writeErrors": [{"index": 1, "code": BAD_VALUE_ERROR}]},
+        msg="delete ordered:true should stop at first error",
+    )
+
+
+def test_delete_ordered_false_continues_on_error(collection):
+    """Test delete ordered:false continues executing past errors."""
+    collection.insert_many([{"_id": i, "a": i} for i in range(5)])
+    result = execute_command(
+        collection,
+        {
+            "delete": collection.name,
+            "deletes": [
+                {"q": {"_id": 1}, "limit": 1},
+                {"q": {"$invalid": 1}, "limit": 1},
+                {"q": {"_id": 3}, "limit": 1},
+            ],
+            "ordered": False,
+        },
+    )
+    assertSuccessPartial(
+        result,
+        {"ok": 1.0, "n": 2, "writeErrors": [{"index": 1, "code": BAD_VALUE_ERROR}]},
+        msg="delete ordered:false should continue past errors",
+    )
+
+
+def test_delete_ordered_true_error_at_first(collection):
+    """Test delete ordered:true with error in first statement returns n:0."""
+    collection.insert_many([{"_id": i} for i in range(3)])
+    result = execute_command(
+        collection,
+        {
+            "delete": collection.name,
+            "deletes": [
+                {"q": {"$invalid": 1}, "limit": 1},
+                {"q": {"_id": 1}, "limit": 1},
+            ],
+            "ordered": True,
+        },
+    )
+    assertSuccessPartial(
+        result,
+        {"ok": 1.0, "n": 0, "writeErrors": [{"index": 0, "code": BAD_VALUE_ERROR}]},
+        msg="delete ordered:true should stop immediately on first error",
+    )
+
+
+def test_delete_ordered_false_error_at_first(collection):
+    """Test delete ordered:false with error in first statement still executes subsequent."""
+    collection.insert_many([{"_id": i} for i in range(3)])
+    result = execute_command(
+        collection,
+        {
+            "delete": collection.name,
+            "deletes": [
+                {"q": {"$invalid": 1}, "limit": 1},
+                {"q": {"_id": 1}, "limit": 1},
+            ],
+            "ordered": False,
+        },
+    )
+    assertSuccessPartial(
+        result,
+        {"ok": 1.0, "n": 1, "writeErrors": [{"index": 0, "code": BAD_VALUE_ERROR}]},
+        msg="delete ordered:false should execute subsequent statements",
+    )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_bulk_operations.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_core_behavior.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_core_behavior.py
@@ -1,0 +1,194 @@
+"""Delete command core behavior tests.
+
+Tests limit behavior, query variations, non-existent collections, response structure,
+and document removal verification.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+    CommandContext,
+    CommandTestCase,
+)
+from documentdb_tests.framework.assertions import assertResult, assertSuccess
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+
+# Property [Limit Zero]: limit:0 removes all matching documents.
+LIMIT_BEHAVIOR_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "limit_zero_removes_all",
+        docs=[{"_id": i, "status": "D"} for i in range(5)] + [{"_id": 99, "status": "A"}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"status": "D"}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 5},
+        msg="delete should remove all matching documents when limit is 0",
+    ),
+    CommandTestCase(
+        "limit_one_removes_single",
+        docs=[{"_id": i, "status": "D"} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"status": "D"}, "limit": 1}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should remove exactly one document when limit is 1",
+    ),
+    CommandTestCase(
+        "empty_query_limit_zero_removes_all",
+        docs=[{"_id": i} for i in range(3)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 3},
+        msg="delete should remove all documents with empty query and limit 0",
+    ),
+    CommandTestCase(
+        "empty_query_limit_one",
+        docs=[{"_id": i} for i in range(3)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 1}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should remove one document with empty query and limit 1",
+    ),
+    CommandTestCase(
+        "no_match_returns_zero",
+        docs=[{"_id": 1, "a": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": 999}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 0},
+        msg="delete should return n:0 when no documents match",
+    ),
+    CommandTestCase(
+        "nonexistent_collection",
+        docs=None,
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 0},
+        msg="delete should succeed with n:0 on non-existent collection",
+    ),
+]
+
+# Property [Query Operators]: delete correctly matches using standard query operators.
+QUERY_VARIATION_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "comparison_gt",
+        docs=[{"_id": i, "val": i} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"val": {"$gt": 2}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should match documents with $gt query",
+    ),
+    CommandTestCase(
+        "in_operator",
+        docs=[{"_id": i, "status": chr(65 + i)} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"status": {"$in": ["A", "C"]}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should match documents with $in query",
+    ),
+    CommandTestCase(
+        "logical_and",
+        docs=[
+            {"_id": 1, "a": 1, "b": 10},
+            {"_id": 2, "a": 1, "b": 20},
+            {"_id": 3, "a": 2, "b": 10},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$and": [{"a": 1}, {"b": 10}]}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match documents with $and query",
+    ),
+    CommandTestCase(
+        "regex_query",
+        docs=[
+            {"_id": 1, "name": "alpha"},
+            {"_id": 2, "name": "beta"},
+            {"_id": 3, "name": "gamma"},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"name": {"$regex": "^a"}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match documents with regex query",
+    ),
+    CommandTestCase(
+        "dot_notation_nested",
+        docs=[{"_id": 1, "a": {"b": 1}}, {"_id": 2, "a": {"b": 2}}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a.b": 1}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match using dot notation",
+    ),
+    CommandTestCase(
+        "exists_true",
+        docs=[{"_id": 1, "a": 1}, {"_id": 2}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": {"$exists": True}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match with $exists:true",
+    ),
+    CommandTestCase(
+        "elemmatch_array",
+        docs=[
+            {"_id": 1, "items": [{"x": 1, "y": 2}, {"x": 3, "y": 4}]},
+            {"_id": 2, "items": [{"x": 5, "y": 6}]},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"items": {"$elemMatch": {"x": 1, "y": 2}}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match with $elemMatch",
+    ),
+]
+
+DELETE_CORE_TESTS: list[CommandTestCase] = LIMIT_BEHAVIOR_TESTS + QUERY_VARIATION_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(DELETE_CORE_TESTS))
+def test_delete_core_behavior(database_client, collection, test):
+    """Test delete command core behavior."""
+    collection = test.prepare(database_client, collection)
+    ctx = CommandContext.from_collection(collection)
+    result = execute_command(collection, test.build_command(ctx))
+    assertResult(
+        result,
+        expected=test.build_expected(ctx),
+        error_code=test.error_code,
+        msg=test.msg,
+        raw_res=True,
+    )
+
+
+def test_delete_verifies_document_removal(collection):
+    """Test delete removes documents from the collection."""
+    collection.insert_many([{"_id": 1, "a": 1}, {"_id": 2, "a": 2}])
+    execute_command(
+        collection,
+        {"delete": collection.name, "deletes": [{"q": {"_id": 1}, "limit": 1}]},
+    )
+    result = execute_command(collection, {"find": collection.name, "filter": {}})
+    assertSuccess(result, [{"_id": 2, "a": 2}], msg="delete should have removed the document")

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_core_behavior.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_core_behavior.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
@@ -11,7 +11,7 @@ from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )
-from documentdb_tests.framework.assertions import assertExceptionType, assertResult
+from documentdb_tests.framework.assertions import assertResult
 from documentdb_tests.framework.error_codes import (
     BAD_VALUE_ERROR,
     COMMAND_NOT_SUPPORTED_ON_VIEW_ERROR,
@@ -215,21 +215,3 @@ def test_delete_error_cases(database_client, collection, test):
         msg=test.msg,
         raw_res=True,
     )
-
-
-def test_delete_deletes_non_array_object_fails(collection):
-    """Test delete with non-array deletes field raises client-side error."""
-    result = execute_command(
-        collection,
-        {"delete": collection.name, "deletes": {"a": 1}},
-    )
-    assertExceptionType(result, TypeError, msg="deletes field must be an array")
-
-
-def test_delete_deletes_non_array_string_fails(collection):
-    """Test delete with non-array deletes field raises client-side error."""
-    result = execute_command(
-        collection,
-        {"delete": collection.name, "deletes": "invalid"},
-    )
-    assertExceptionType(result, TypeError, msg="deletes field must be an array")

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
@@ -1,0 +1,225 @@
+"""Delete command error cases.
+
+All error code assertions for the delete command consolidated in one file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+    CommandContext,
+    CommandTestCase,
+)
+from documentdb_tests.framework.assertions import assertExceptionType, assertResult
+from documentdb_tests.framework.error_codes import (
+    BAD_VALUE_ERROR,
+    COMMAND_NOT_SUPPORTED_ON_VIEW_ERROR,
+    FAILED_TO_PARSE_ERROR,
+    INVALID_LENGTH_ERROR,
+    INVALID_NAMESPACE_ERROR,
+    MISSING_FIELD_ERROR,
+    TYPE_MISMATCH_ERROR,
+    UNRECOGNIZED_COMMAND_FIELD_ERROR,
+)
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+from documentdb_tests.framework.target_collection import ViewCollection
+
+# Property [Field Validation]: the delete command rejects invalid field types and values.
+DELETE_ERROR_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "delete_field_non_string_int",
+        docs=[],
+        command=lambda ctx: {
+            "delete": 32,
+            "deletes": [{"q": {}, "limit": 1}],
+        },
+        error_code=INVALID_NAMESPACE_ERROR,
+        msg="delete should reject non-string collection name",
+    ),
+    CommandTestCase(
+        "delete_field_empty_string",
+        docs=[],
+        command=lambda ctx: {
+            "delete": "",
+            "deletes": [{"q": {}, "limit": 1}],
+        },
+        error_code=INVALID_NAMESPACE_ERROR,
+        msg="delete should reject empty string collection name",
+    ),
+    CommandTestCase(
+        "delete_field_null_byte",
+        docs=[],
+        command=lambda ctx: {
+            "delete": "test\x00evil",
+            "deletes": [{"q": {}, "limit": 1}],
+        },
+        error_code=INVALID_NAMESPACE_ERROR,
+        msg="delete should reject null byte in collection name",
+    ),
+    CommandTestCase(
+        "missing_deletes_field",
+        docs=[],
+        command=lambda ctx: {"delete": ctx.collection},
+        error_code=MISSING_FIELD_ERROR,
+        msg="delete should require deletes field",
+    ),
+    CommandTestCase(
+        "empty_deletes_array",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [],
+        },
+        error_code=INVALID_LENGTH_ERROR,
+        msg="delete should reject empty deletes array",
+    ),
+    CommandTestCase(
+        "unknown_top_level_field",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 1}],
+            "unknownField": 1,
+        },
+        error_code=UNRECOGNIZED_COMMAND_FIELD_ERROR,
+        msg="delete should reject unknown top-level fields",
+    ),
+    CommandTestCase(
+        "let_non_object",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 1}],
+            "let": "invalid",
+        },
+        error_code=TYPE_MISMATCH_ERROR,
+        msg="delete should reject non-object let field",
+    ),
+    CommandTestCase(
+        "statement_missing_q",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"limit": 1}],
+        },
+        error_code=MISSING_FIELD_ERROR,
+        msg="delete should require q field in statement",
+    ),
+    CommandTestCase(
+        "statement_missing_limit",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}}],
+        },
+        error_code=MISSING_FIELD_ERROR,
+        msg="delete should require limit field in statement",
+    ),
+    CommandTestCase(
+        "statement_q_non_object",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": "not_object", "limit": 1}],
+        },
+        error_code=TYPE_MISMATCH_ERROR,
+        msg="delete should reject non-object q field",
+    ),
+    CommandTestCase(
+        "statement_limit_value_2",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 2}],
+        },
+        error_code=FAILED_TO_PARSE_ERROR,
+        msg="delete should reject limit values other than 0 or 1",
+    ),
+    CommandTestCase(
+        "statement_limit_negative",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": -1}],
+        },
+        error_code=FAILED_TO_PARSE_ERROR,
+        msg="delete should reject negative limit",
+    ),
+    CommandTestCase(
+        "statement_unknown_field",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 1, "unknownField": 1}],
+        },
+        error_code=UNRECOGNIZED_COMMAND_FIELD_ERROR,
+        msg="delete should reject unknown fields in statement",
+    ),
+    CommandTestCase(
+        "hint_nonexistent_index",
+        docs=[{"_id": 1, "a": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": 1}, "limit": 1, "hint": {"nonexistent": 1}}],
+        },
+        error_code=BAD_VALUE_ERROR,
+        msg="delete should reject hint pointing to non-existent index",
+    ),
+    CommandTestCase(
+        "delete_on_view",
+        target_collection=ViewCollection(),
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 0}],
+        },
+        error_code=COMMAND_NOT_SUPPORTED_ON_VIEW_ERROR,
+        msg="delete should not work on views",
+    ),
+    CommandTestCase(
+        "ordered_non_boolean_string",
+        docs=[],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "ordered": "true",
+            "deletes": [{"q": {}, "limit": 1}],
+        },
+        error_code=TYPE_MISMATCH_ERROR,
+        msg="delete should reject non-boolean ordered field",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", pytest_params(DELETE_ERROR_TESTS))
+def test_delete_error_cases(database_client, collection, test):
+    """Test delete command error cases."""
+    collection = test.prepare(database_client, collection)
+    ctx = CommandContext.from_collection(collection)
+    result = execute_command(collection, test.build_command(ctx))
+    assertResult(
+        result,
+        expected=test.build_expected(ctx),
+        error_code=test.error_code,
+        msg=test.msg,
+        raw_res=True,
+    )
+
+
+def test_delete_deletes_non_array_object_fails(collection):
+    """Test delete with non-array deletes field raises client-side error."""
+    result = execute_command(
+        collection,
+        {"delete": collection.name, "deletes": {"a": 1}},
+    )
+    assertExceptionType(result, TypeError, msg="deletes field must be an array")
+
+
+def test_delete_deletes_non_array_string_fails(collection):
+    """Test delete with non-array deletes field raises client-side error."""
+    result = execute_command(
+        collection,
+        {"delete": collection.name, "deletes": "invalid"},
+    )
+    assertExceptionType(result, TypeError, msg="deletes field must be an array")

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
@@ -27,6 +27,10 @@ from documentdb_tests.framework.parametrize import pytest_params
 from documentdb_tests.framework.target_collection import ViewCollection
 
 # Property [Field Validation]: the delete command rejects invalid field types and values.
+# Wire-protocol namespace validation (INVALID_NAMESPACE_ERROR for non-string collection name
+# types) is foundational behavior per TEST_COVERAGE.md §19. One representative case wires
+# delete to that behavior; the full type matrix belongs in the centralized namespace test
+# site (currently TBD).
 DELETE_ERROR_TESTS: list[CommandTestCase] = [
     CommandTestCase(
         "delete_field_non_string_int",
@@ -168,17 +172,6 @@ DELETE_ERROR_TESTS: list[CommandTestCase] = [
         msg="delete should reject hint pointing to non-existent index",
     ),
     CommandTestCase(
-        "delete_on_view",
-        target_collection=ViewCollection(),
-        docs=[{"_id": 1}],
-        command=lambda ctx: {
-            "delete": ctx.collection,
-            "deletes": [{"q": {}, "limit": 0}],
-        },
-        error_code=COMMAND_NOT_SUPPORTED_ON_VIEW_ERROR,
-        msg="delete should not work on views",
-    ),
-    CommandTestCase(
         "ordered_non_boolean_string",
         docs=[],
         command=lambda ctx: {
@@ -191,8 +184,25 @@ DELETE_ERROR_TESTS: list[CommandTestCase] = [
     ),
 ]
 
+# Property [Collection Variant Rejection]: the delete command rejects unsupported collection types.
+COLLECTION_VARIANT_ERROR_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "delete_on_view",
+        target_collection=ViewCollection(),
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {}, "limit": 0}],
+        },
+        error_code=COMMAND_NOT_SUPPORTED_ON_VIEW_ERROR,
+        msg="delete should not work on views",
+    ),
+]
 
-@pytest.mark.parametrize("test", pytest_params(DELETE_ERROR_TESTS))
+DELETE_ERROR_TESTS_ALL: list[CommandTestCase] = DELETE_ERROR_TESTS + COLLECTION_VARIANT_ERROR_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(DELETE_ERROR_TESTS_ALL))
 def test_delete_error_cases(database_client, collection, test):
     """Test delete command error cases."""
     collection = test.prepare(database_client, collection)

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_error_cases.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_null_and_types.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_null_and_types.py
@@ -1,0 +1,160 @@
+"""Delete command null handling and BSON type distinction tests.
+
+Tests null/missing field matching semantics and BSON type distinction in queries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from bson import Binary, Code, Decimal128, Int64, MaxKey, MinKey, ObjectId, Regex, Timestamp
+
+from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+    CommandContext,
+    CommandTestCase,
+)
+from documentdb_tests.framework.assertions import assertResult
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+from documentdb_tests.framework.test_constants import DATE_EPOCH
+
+# Property [Null Semantics]: q:{field:null} matches both null values and missing fields.
+NULL_MATCHING_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "null_matches_null_and_missing",
+        docs=[{"_id": 1, "a": None}, {"_id": 2, "a": 1}, {"_id": 3}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": None}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should match both null and missing fields",
+    ),
+    CommandTestCase(
+        "type_null_matches_only_explicit",
+        docs=[{"_id": 1, "a": None}, {"_id": 2, "a": 1}, {"_id": 3}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": {"$type": "null"}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match only explicit null with $type:null",
+    ),
+    CommandTestCase(
+        "exists_false_matches_only_missing",
+        docs=[{"_id": 1, "a": None}, {"_id": 2, "a": 1}, {"_id": 3}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": {"$exists": False}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match only missing field with $exists:false",
+    ),
+]
+
+# Property [BSON Type Distinction]: queries distinguish between BSON types correctly.
+TYPE_DISTINCTION_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "false_does_not_match_zero",
+        docs=[{"_id": 1, "a": False}, {"_id": 2, "a": 0}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": False}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should not match int 0 when querying for false",
+    ),
+    CommandTestCase(
+        "true_does_not_match_one",
+        docs=[{"_id": 1, "a": True}, {"_id": 2, "a": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": True}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should not match int 1 when querying for true",
+    ),
+    CommandTestCase(
+        "empty_string_does_not_match_null",
+        docs=[{"_id": 1, "a": ""}, {"_id": 2, "a": None}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": ""}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should not match null when querying for empty string",
+    ),
+    CommandTestCase(
+        "zero_matches_all_numeric_zeros",
+        docs=[
+            {"_id": 1, "a": 0},
+            {"_id": 2, "a": Int64(0)},
+            {"_id": 3, "a": 0.0},
+            {"_id": 4, "a": Decimal128("0")},
+            {"_id": 5, "a": 1},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": 0}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 4},
+        msg="delete should match all numeric zero representations",
+    ),
+]
+
+DELETE_NULL_AND_TYPES_TESTS: list[CommandTestCase] = NULL_MATCHING_TESTS + TYPE_DISTINCTION_TESTS
+
+
+@pytest.mark.parametrize("test", pytest_params(DELETE_NULL_AND_TYPES_TESTS))
+def test_delete_null_and_types(database_client, collection, test):
+    """Test delete command null matching and type distinction."""
+    collection = test.prepare(database_client, collection)
+    ctx = CommandContext.from_collection(collection)
+    result = execute_command(collection, test.build_command(ctx))
+    assertResult(
+        result,
+        expected=test.build_expected(ctx),
+        error_code=test.error_code,
+        msg=test.msg,
+        raw_res=True,
+    )
+
+
+_BSON_TYPE_DOCS: list[dict[str, Any]] = [
+    {"_id": "double", "val": 3.14},
+    {"_id": "string", "val": "hello"},
+    {"_id": "object", "val": {"k": "v"}},
+    {"_id": "array", "val": [1, 2, 3]},
+    {"_id": "binary", "val": Binary(b"\x01\x02")},
+    {"_id": "objectid", "val": ObjectId("000000000000000000000001")},
+    {"_id": "bool", "val": True},
+    {"_id": "date", "val": DATE_EPOCH},
+    {"_id": "null", "val": None},
+    {"_id": "regex", "val": Regex("^a", "i")},
+    {"_id": "javascript", "val": Code("function(){}")},
+    {"_id": "int", "val": 42},
+    {"_id": "timestamp", "val": Timestamp(1, 1)},
+    {"_id": "long", "val": Int64(123456)},
+    {"_id": "decimal", "val": Decimal128("1.5")},
+    {"_id": "minkey", "val": MinKey()},
+    {"_id": "maxkey", "val": MaxKey()},
+]
+
+_BSON_TYPE_PARAMS = [pytest.param(doc["_id"], id=doc["_id"]) for doc in _BSON_TYPE_DOCS]
+
+
+@pytest.mark.parametrize("type_id", _BSON_TYPE_PARAMS)
+def test_delete_document_with_bson_type(collection, type_id):
+    """Test delete can remove documents containing each BSON type."""
+    collection.insert_many(_BSON_TYPE_DOCS)
+    result = execute_command(
+        collection,
+        {"delete": collection.name, "deletes": [{"q": {"_id": type_id}, "limit": 1}]},
+    )
+    assertResult(
+        result,
+        expected={"ok": 1.0, "n": 1},
+        msg=f"delete should remove document with {type_id} field",
+        raw_res=True,
+    )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_null_and_types.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_null_and_types.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 from bson import Binary, Code, Decimal128, Int64, MaxKey, MinKey, ObjectId, Regex, Timestamp
 
-from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_options.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_options.py
@@ -1,0 +1,215 @@
+"""Delete command options tests.
+
+Tests hint, collation wiring, let variables, comment, ordered, and writeConcern.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pymongo import ASCENDING, IndexModel
+
+from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+    CommandContext,
+    CommandTestCase,
+)
+from documentdb_tests.framework.assertions import assertResult
+from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
+
+# Property [Option Acceptance]: the delete command accepts all documented optional fields.
+DELETE_OPTIONS_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "hint_index_spec_document",
+        docs=[{"_id": i, "status": "D"} for i in range(3)],
+        indexes=[IndexModel([("status", ASCENDING)])],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"status": "D"}, "limit": 0, "hint": {"status": 1}}],
+        },
+        expected={"ok": 1.0, "n": 3},
+        msg="delete should accept hint as index spec document",
+    ),
+    CommandTestCase(
+        "hint_index_name_string",
+        docs=[{"_id": i, "status": "D"} for i in range(2)],
+        indexes=[IndexModel([("status", ASCENDING)], name="status_idx")],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"status": "D"}, "limit": 0, "hint": "status_idx"}],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should accept hint as index name string",
+    ),
+    CommandTestCase(
+        "hint_id_index",
+        docs=[{"_id": 1, "a": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1, "hint": {"_id": 1}}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept _id index hint",
+    ),
+    CommandTestCase(
+        "hint_compound_index",
+        docs=[{"_id": i, "a": 1, "b": i} for i in range(3)],
+        indexes=[IndexModel([("a", ASCENDING), ("b", ASCENDING)])],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"a": 1, "b": 1}, "limit": 1, "hint": {"a": 1, "b": 1}}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept compound index hint",
+    ),
+    CommandTestCase(
+        "let_string_variable",
+        docs=[{"_id": 1, "status": "active"}, {"_id": 2, "status": "inactive"}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$eq": ["$status", "$$target"]}}, "limit": 0}],
+            "let": {"target": "inactive"},
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should resolve string let variable",
+    ),
+    CommandTestCase(
+        "let_numeric_variable",
+        docs=[{"_id": i, "score": i * 10} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$lt": ["$score", "$$threshold"]}}, "limit": 0}],
+            "let": {"threshold": 30},
+        },
+        expected={"ok": 1.0, "n": 3},
+        msg="delete should resolve numeric let variable",
+    ),
+    CommandTestCase(
+        "let_array_variable",
+        docs=[{"_id": i} for i in range(5)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$in": ["$_id", "$$ids"]}}, "limit": 0}],
+            "let": {"ids": [1, 3]},
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should resolve array let variable",
+    ),
+    CommandTestCase(
+        "let_empty_document",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "let": {},
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept empty let document",
+    ),
+    CommandTestCase(
+        "comment_string",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "comment": "test deletion",
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept string comment",
+    ),
+    CommandTestCase(
+        "comment_object",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "comment": {"app": "test", "op": "cleanup"},
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept object comment",
+    ),
+    CommandTestCase(
+        "ordered_true",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "ordered": True,
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept ordered:true",
+    ),
+    CommandTestCase(
+        "ordered_false",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "ordered": False,
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept ordered:false",
+    ),
+    CommandTestCase(
+        "writeconcern_w1",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "writeConcern": {"w": 1},
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept writeConcern w:1",
+    ),
+    CommandTestCase(
+        "writeconcern_majority",
+        docs=[{"_id": 1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"_id": 1}, "limit": 1}],
+            "writeConcern": {"w": "majority"},
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should accept writeConcern w:majority",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", pytest_params(DELETE_OPTIONS_TESTS))
+def test_delete_options(database_client, collection, test):
+    """Test delete command options acceptance."""
+    collection = test.prepare(database_client, collection)
+    ctx = CommandContext.from_collection(collection)
+    result = execute_command(collection, test.build_command(ctx))
+    assertResult(
+        result,
+        expected=test.build_expected(ctx),
+        error_code=test.error_code,
+        msg=test.msg,
+        raw_res=True,
+    )
+
+
+def test_delete_collation_case_insensitive_wiring(collection):
+    """Test delete accepts collation for case-insensitive matching."""
+    collection.insert_many(
+        [
+            {"_id": 1, "name": "Cafe"},
+            {"_id": 2, "name": "cafe"},
+            {"_id": 3, "name": "CAFE"},
+        ]
+    )
+    result = execute_command(
+        collection,
+        {
+            "delete": collection.name,
+            "deletes": [
+                {"q": {"name": "cafe"}, "limit": 0, "collation": {"locale": "en", "strength": 2}}
+            ],
+        },
+    )
+    assertResult(
+        result,
+        expected={"ok": 1.0, "n": 3},
+        msg="delete should use collation for case-insensitive match",
+        raw_res=True,
+    )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_options.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_options.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 from pymongo import ASCENDING, IndexModel
 
-from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_with_expr.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_with_expr.py
@@ -1,81 +1,73 @@
-"""
-Tests for $expr in delete command contexts.
+"""Delete command $expr filter tests.
+
+Tests $expr usage in delete query filters per Rule 17.
 """
 
-from documentdb_tests.framework.assertions import assertSuccess
+from __future__ import annotations
+
+import pytest
+
+from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+    CommandContext,
+    CommandTestCase,
+)
+from documentdb_tests.framework.assertions import assertResult
 from documentdb_tests.framework.executor import execute_command
+from documentdb_tests.framework.parametrize import pytest_params
 
-BASIC_DOCS = [
-    {"_id": 1, "a": 5, "b": 3},
-    {"_id": 2, "a": 1, "b": 10},
-    {"_id": 3, "a": -1, "b": 0},
-]
-
-
-def test_expr_in_delete_many(collection):
-    """Test $expr in deleteMany filter."""
-    collection.insert_many(BASIC_DOCS)
-    result = execute_command(
-        collection,
-        {
-            "delete": collection.name,
-            "deletes": [{"q": {"$expr": {"$lt": ["$a", 0]}}, "limit": 0}],
+# Property [$expr Support]: delete resolves $expr filter expressions including cross-field
+# comparisons, logical operators, nested expressions, and let variables.
+DELETE_EXPR_TESTS: list[CommandTestCase] = [
+    CommandTestCase(
+        "expr_equality",
+        docs=[{"_id": 1, "status": "D"}, {"_id": 2, "status": "A"}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$eq": ["$status", "D"]}}, "limit": 0}],
         },
-    )
-    assertSuccess(result, {"n": 1, "ok": 1.0}, raw_res=True)
-
-
-def test_expr_let_in_delete(collection):
-    """Test $expr with let variable in delete command."""
-    collection.insert_many(BASIC_DOCS)
-    result = execute_command(
-        collection,
-        {
-            "delete": collection.name,
-            "deletes": [{"q": {"$expr": {"$eq": ["$a", "$$target"]}}, "limit": 0}],
-            "let": {"target": -1},
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match via $expr $eq",
+    ),
+    CommandTestCase(
+        "expr_cross_field_comparison",
+        docs=[{"_id": 1, "a": 5, "b": 3}, {"_id": 2, "a": 1, "b": 10}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$gt": ["$a", "$b"]}}, "limit": 0}],
         },
-    )
-    assertSuccess(result, {"n": 1, "ok": 1.0}, raw_res=True)
-
-
-def test_expr_delete_with_in(collection):
-    """Test $expr in deleteMany with $in on array field."""
-    collection.insert_many([{"_id": 1, "tags": [True, False]}, {"_id": 2, "tags": [False]}])
-    result = execute_command(
-        collection,
-        {
-            "delete": collection.name,
-            "deletes": [{"q": {"$expr": {"$in": [True, "$tags"]}}, "limit": 0}],
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should match via $expr cross-field comparison",
+    ),
+    CommandTestCase(
+        "expr_and_logic",
+        docs=[
+            {"_id": 1, "a": 5, "b": 3},
+            {"_id": 2, "a": 1, "b": 8},
+            {"_id": 3, "a": 5, "b": 8},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [
+                {"q": {"$expr": {"$and": [{"$gt": ["$a", 2]}, {"$gt": ["$b", 5]}]}}, "limit": 0}
+            ],
         },
-    )
-    assertSuccess(result, {"n": 1, "ok": 1.0}, raw_res=True)
-
-
-def test_expr_delete_with_cond(collection):
-    """Test $expr in deleteMany with $cond expression."""
-    collection.insert_many(
-        [
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should support $and inside $expr",
+    ),
+    CommandTestCase(
+        "expr_nested_expression",
+        docs=[
             {"_id": 1, "price": 100, "discount": 0.2},
             {"_id": 2, "price": 50, "discount": 0.1},
-        ]
-    )
-    result = execute_command(
-        collection,
-        {
-            "delete": collection.name,
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
             "deletes": [
                 {
                     "q": {
                         "$expr": {
                             "$lt": [
-                                {
-                                    "$cond": [
-                                        {"$gt": ["$discount", 0]},
-                                        {"$multiply": ["$price", {"$subtract": [1, "$discount"]}]},
-                                        "$price",
-                                    ]
-                                },
+                                {"$multiply": ["$price", {"$subtract": [1, "$discount"]}]},
                                 60,
                             ]
                         }
@@ -84,5 +76,63 @@ def test_expr_delete_with_cond(collection):
                 }
             ],
         },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should support nested expressions in $expr",
+    ),
+    CommandTestCase(
+        "expr_with_let_variable",
+        docs=[{"_id": 1, "a": 5}, {"_id": 2, "a": -1}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$eq": ["$a", "$$target"]}}, "limit": 0}],
+            "let": {"target": -1},
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should resolve $$variable in $expr",
+    ),
+    CommandTestCase(
+        "expr_no_match",
+        docs=[{"_id": 1, "a": 1}, {"_id": 2, "a": 2}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$gt": ["$a", 100]}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 0},
+        msg="delete should return n:0 when $expr matches nothing",
+    ),
+    CommandTestCase(
+        "expr_matches_all",
+        docs=[{"_id": i, "a": i} for i in range(3)],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$gte": ["$a", 0]}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 3},
+        msg="delete should delete all when $expr matches all",
+    ),
+    CommandTestCase(
+        "expr_nonexistent_field",
+        docs=[{"_id": 1, "a": 1}, {"_id": 2, "a": 2}],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$gt": ["$nonexistent", 0]}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 0},
+        msg="delete should not match when $expr references missing field",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", pytest_params(DELETE_EXPR_TESTS))
+def test_delete_with_expr(database_client, collection, test):
+    """Test delete command $expr filter support."""
+    collection = test.prepare(database_client, collection)
+    ctx = CommandContext.from_collection(collection)
+    result = execute_command(collection, test.build_command(ctx))
+    assertResult(
+        result,
+        expected=test.build_expected(ctx),
+        error_code=test.error_code,
+        msg=test.msg,
+        raw_res=True,
     )
-    assertSuccess(result, {"n": 1, "ok": 1.0}, raw_res=True)

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_with_expr.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_with_expr.py
@@ -16,7 +16,8 @@ from documentdb_tests.framework.executor import execute_command
 from documentdb_tests.framework.parametrize import pytest_params
 
 # Property [$expr Support]: delete resolves $expr filter expressions including cross-field
-# comparisons, logical operators, nested expressions, and let variables.
+# comparisons, logical operators ($and, $or), nested expressions, let variables, and nested
+# aggregation operators.
 DELETE_EXPR_TESTS: list[CommandTestCase] = [
     CommandTestCase(
         "expr_equality",
@@ -119,6 +120,46 @@ DELETE_EXPR_TESTS: list[CommandTestCase] = [
         },
         expected={"ok": 1.0, "n": 0},
         msg="delete should not match when $expr references missing field",
+    ),
+    CommandTestCase(
+        "expr_or_logic",
+        docs=[
+            {"_id": 1, "status": "D"},
+            {"_id": 2, "status": "X"},
+            {"_id": 3, "status": "A"},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [
+                {
+                    "q": {
+                        "$expr": {
+                            "$or": [
+                                {"$eq": ["$status", "D"]},
+                                {"$eq": ["$status", "X"]},
+                            ]
+                        }
+                    },
+                    "limit": 0,
+                }
+            ],
+        },
+        expected={"ok": 1.0, "n": 2},
+        msg="delete should support $or inside $expr",
+    ),
+    CommandTestCase(
+        "expr_nested_size_operator",
+        docs=[
+            {"_id": 1, "tags": ["a", "b", "c"]},
+            {"_id": 2, "tags": ["x"]},
+            {"_id": 3, "tags": ["p", "q"]},
+        ],
+        command=lambda ctx: {
+            "delete": ctx.collection,
+            "deletes": [{"q": {"$expr": {"$gt": [{"$size": "$tags"}, 2]}}, "limit": 0}],
+        },
+        expected={"ok": 1.0, "n": 1},
+        msg="delete should support nested aggregation operators inside $expr",
     ),
 ]
 

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_with_expr.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_delete_with_expr.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from documentdb_tests.compatibility.tests.core.collections.commands.utils.command_test_case import (
+from documentdb_tests.compatibility.tests.core.utils.command_test_case import (
     CommandContext,
     CommandTestCase,
 )

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_smoke_delete.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_smoke_delete.py
@@ -13,15 +13,12 @@ pytestmark = pytest.mark.smoke
 
 
 def test_smoke_delete(collection):
-    """Test basic delete command behavior."""
-    collection.insert_many(
-        [{"_id": 1, "name": "Alice"}, {"_id": 2, "name": "Bob"}, {"_id": 3, "name": "Charlie"}]
-    )
+    """Test basic delete command removes a single document."""
+    collection.insert_many([{"_id": 1, "a": 1}, {"_id": 2, "a": 2}, {"_id": 3, "a": 3}])
 
     result = execute_command(
         collection,
         {"delete": collection.name, "deletes": [{"q": {"_id": 1}, "limit": 1}]},
     )
 
-    expected = {"ok": 1.0, "n": 1}
-    assertSuccessPartial(result, expected, msg="Should support delete command")
+    assertSuccessPartial(result, {"ok": 1.0, "n": 1}, msg="delete should remove one document")

--- a/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_smoke_delete.py
+++ b/documentdb_tests/compatibility/tests/core/query_and_write/commands/delete/test_smoke_delete.py
@@ -1,5 +1,4 @@
-"""
-Smoke test for delete command.
+"""Smoke test for the delete command.
 
 Tests basic delete command functionality.
 """


### PR DESCRIPTION
#39 
Test cases: 88
Docs: https://www.mongodb.com/docs/v8.2/reference/command/delete/

Adds compatibility test coverage for the query-and-write delete command, validating its full surface area - from basic document deletion and limit semantics to BSON type distinction, null/missing field matching, ordered/unordered error handling, $expr filter support, hint/let/collation option wiring, and argument type rejection - across document types and edge cases.

88 test cases across 7 files following project test guidelines.

Also renames the query-and-write directory tree to use underscores (query_and_write) for valid Python package naming, and renames read-concern and write-concern subdirectories accordingly.