### PR TITLE
Add amazon-documentdb engine capability profile

### DIFF
--- a/documentdb_tests/framework/preconditions.py
+++ b/documentdb_tests/framework/preconditions.py
@@ -109,6 +109,27 @@ _CAPABILITIES_BY_PROFILE: dict[tuple[str, str], frozenset[str]] = {
             "validate_repair",
         }
     ),
+    # Amazon DocumentDB. A managed, replicated deployment: it presents the
+    # DocumentDB capability surface and, being backed by a replica set,
+    # additionally has the replication-dependent capabilities the reference
+    # server gates behind one (oplog access). Exposed as a single deployment
+    # form, so its one topology is named ``replica_set``.
+    ("amazon-documentdb", "replica_set"): frozenset(
+        {
+            "change_streams",
+            "transactions",
+            "queryable_encryption",
+            "cluster_admin",
+            "cluster_time",
+            "cluster_read_concern",
+            "quorum_write_concern",
+            "oplog",
+            "unforced_compact",
+            "reindex",
+            "replication",
+            "validate_repair",
+        }
+    ),
 }
 
 # The single marker tests use to declare capability requirements.
@@ -159,6 +180,12 @@ def _detect_topology(engine: str, client: MongoClient) -> str:
         # and resolves to no capabilities rather than the full set.
         client.admin.command("hello")
         return "standalone"
+    if engine == "amazon-documentdb":
+        # Amazon DocumentDB is exposed as a single, replicated deployment form.
+        # Issue hello so an unreachable target raises here and resolves to no
+        # capabilities rather than the full set.
+        client.admin.command("hello")
+        return "replica_set"
     raise ValueError(f"unknown engine {engine!r}; cannot classify topology")
 
 


### PR DESCRIPTION
## What

Registers an `amazon-documentdb` engine target in the capability framework so the suite can run against **Amazon DocumentDB** via `--engine-name amazon-documentdb --connection-string <uri>`.

## Why

`known_engines()` currently resolves only `mongodb` and `documentdb`. Pointing the suite at an Amazon DocumentDB endpoint with `--engine-name amazon-documentdb` fails at `pytest_configure`:

```
--engine-name must be one of ['documentdb', 'mongodb'] when --connection-string is given, got 'amazon-documentdb'
```

Amazon DocumentDB is the DocumentDB engine deployed as a managed, replicated cluster. It is distinct from the open-source `documentdb` standalone profile because, being backed by a replica set, it additionally exhibits the replication-dependent capabilities the reference server gates behind one.

## Changes

- Add `("amazon-documentdb", "replica_set")` to `_CAPABILITIES_BY_PROFILE`: the DocumentDB capability surface **plus** `oplog` (the replica-set-gated capability), under a single `replica_set` topology.
- Teach `_detect_topology` to recognize `amazon-documentdb` (issues `hello` so an unreachable target resolves to no capabilities, mirroring the `documentdb` path), returning `replica_set`.

`_check_consistency()` still passes (no new capability names introduced — all already described). `known_engines()` now returns `{amazon-documentdb, documentdb, mongodb}`.

This is framework-only; no test behavior changes for existing `mongodb`/`documentdb` targets.

## Testing

- Module imports cleanly (runs `_check_consistency()` at import).
- `known_engines()` includes `amazon-documentdb`; the profile resolves to the expected capability set.
- `black`, `isort`, `flake8`, `mypy` all pass on the changed file.