### PR TITLE
Report test results broken down by project structure

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -115,13 +115,14 @@ jobs:
         if: always()
         run: |
           REPORT=${{ github.workspace }}/.test-results/${{ matrix.target.name }}-report.json
-          ANALYSIS=${{ github.workspace }}/.test-results/${{ matrix.target.name }}-analysis.txt
+          ANALYSIS=${{ github.workspace }}/.test-results/${{ matrix.target.name }}-analysis.md
           if [ -f "$REPORT" ]; then
-            python -m documentdb_tests.compatibility.result_analyzer -i "$REPORT" -o "$ANALYSIS" -f text || true
+            # Emit GitHub-flavored markdown (tables + collapsible <details>) and
+            # write it unfenced so the step summary renders it, rather than
+            # dumping preformatted text inside a code block.
+            python -m documentdb_tests.compatibility.result_analyzer -i "$REPORT" -o "$ANALYSIS" -f markdown || true
             echo "## ${{ matrix.target.name }} Test Results" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
             cat "$ANALYSIS" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
   # Crash tests kill the server, so each runs in isolation in its own job (one

--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ docdb-analyze --input custom-results.json
 # Generate text report
 docdb-analyze --output report.txt --format text
 
+# Generate a markdown report (for a GitHub step summary)
+docdb-analyze --output report.md --format markdown
+
 # Generate JSON analysis
 docdb-analyze --output analysis.json --format json
 
@@ -394,6 +397,9 @@ print_summary(analysis)
 
 # Generate text report
 generate_report(analysis, "report.txt", format="text")
+
+# Generate a markdown report (for a GitHub step summary)
+generate_report(analysis, "report.md", format="markdown")
 
 # Generate JSON report
 generate_report(analysis, "report.json", format="json")

--- a/docs/testing/TEST_FORMAT.md
+++ b/docs/testing/TEST_FORMAT.md
@@ -118,6 +118,40 @@ def test_divide(collection, test):
 - `msg` is **required** — describes expected behavior, not input
 - Use constants from `framework.test_constants` (`INT32_MAX`, `FLOAT_NAN`, etc.) and `framework.error_codes` (`TYPE_MISMATCH_ERROR`, etc.)
 
+## Marker Reasons
+
+Markers that suppress or reclassify a test's outcome must always explain why, so a
+run never has an unexplained skipped/xfailed test. This is checked statically at
+collection time.
+
+```python
+# ✅ Good
+@pytest.mark.skip(reason="Requires Atlas Search configuration")
+@pytest.mark.engine_xfail(engine="mongodb", reason="MongoDB misparses multi-digit years")
+
+# ❌ Bad — no reason
+@pytest.mark.skip
+@pytest.mark.engine_xfail(engine="mongodb")
+```
+
+Applies to `skip`, `skipif`, `xfail`, `engine_xfail`, and `engine_xcrash`. The
+same rule covers runtime `pytest.skip()` / `fail()` / `xfail()` calls, via their
+message argument:
+
+```python
+# ✅ Good
+pytest.skip("Engine supports this; skipping not-supported test")
+pytest.skip(f"Unrecognized os.type {os_type!r}; skipping platform-specific check")
+
+# ❌ Bad — no message
+pytest.skip()
+```
+
+The explanation must be **present**, and if written as a string literal it must be
+**non-empty**. A non-literal explanation (a shared constant or an f-string) is
+accepted — a static check can't resolve its value — so a reason constant reused
+across cases and a runtime message embedding dynamic context are both fine.
+
 ## Validation
 
 A pytest hook auto-validates during collection:
@@ -126,3 +160,5 @@ A pytest hook auto-validates during collection:
 - Must use assertion helpers, not plain `assert`
 - One assertion per test function
 - Must use `execute_command()` or helpers from utils
+- Outcome-suppressing markers must carry a `reason=`, and runtime
+  `pytest.skip()`/`fail()`/`xfail()` calls must pass a message (see Marker Reasons)

--- a/docs/testing/TEST_FORMAT.md
+++ b/docs/testing/TEST_FORMAT.md
@@ -152,6 +152,15 @@ The explanation must be **present**, and if written as a string literal it must 
 accepted — a static check can't resolve its value — so a reason constant reused
 across cases and a runtime message embedding dynamic context are both fine.
 
+## Strict xfail
+
+`engine_xfail` is **strict**: the marked test is expected to fail on that engine,
+and if it *passes* the run fails with an `[XPASS(strict)]` error rather than
+silently tolerating the unexpected pass. This is deliberate — a documented gap
+that the server has since fixed should surface loudly so the stale marker is
+removed and the test resumes guarding real behavior. If a test starts failing
+with `[XPASS(strict)]`, delete its `engine_xfail` marker.
+
 ## Validation
 
 A pytest hook auto-validates during collection:

--- a/documentdb_tests/compatibility/result_analyzer/README.md
+++ b/documentdb_tests/compatibility/result_analyzer/README.md
@@ -1,106 +1,67 @@
 # Result Analyzer
 
-The Result Analyzer automatically processes pytest JSON reports and categorizes results by registered test markers.
+Processes a pytest JSON report and generates a compatibility report, grouped by
+feature, for a target engine.
 
-## Features
+## What it produces
 
-- **Dynamic Marker Loading**: Reads markers directly from `pytest.ini` configuration
-- **Single Source of Truth**: Markers defined only in `pytest.ini`
-- **Configurable**: Can analyze reports from different projects with different marker configurations
-- **CLI Tool**: `docdb-analyze` command for quick analysis
-- **Class-Based API**: Testable, multi-context support
+From a pytest-json-report file it builds:
 
-## Marker Detection
+- A **verdict** (PASS / FAIL) with a one-line reason.
+- A **breakdown** reconciling the run: collected = unsupported (deselected) +
+  executed, and executed = passed + failed + errored + skipped + known gaps.
+- **Needs attention**: failures and errors grouped by failure type, each with
+  its traceback (capped for mass failures).
+- **Known gaps**: xfailed tests (documented incompatibilities) with their reasons.
+- **Skipped**: skipped tests with their reasons.
+- **Feature breakdown**: a collapsible tree of pass/fail counts per feature,
+  derived from each test's path (`core/operator/expressions/...`), down to the
+  test file.
 
-The analyzer uses a **whitelist approach** by reading registered markers from `pytest.ini`:
+## Feature grouping
 
-1. Parses the `[pytest]` markers section in `pytest.ini`
-2. Extracts all registered marker names
-3. Only includes markers that are explicitly registered
-4. Automatically ignores pytest internals, test names, file paths, etc.
+Grouping comes from the test's node id path, not from markers: the directory
+tree under `tests/` *is* the feature taxonomy. Each path component is a tier
+(area → category → family → operator → file), so no marker registration or
+configuration is needed.
 
-### Registered Markers
-All markers used for categorization must be registered in `pytest.ini`:
+## Failure categorization
 
-```ini
-[pytest]
-markers =
-    find: Find operation tests
-    insert: Insert operation tests
-    aggregate: Aggregation pipeline tests
-    smoke: Quick smoke tests
-    slow: Tests that take longer to execute
-```
+Failures/errors are tagged by the framework's assertion prefix (e.g.
+`RESULT_MISMATCH`, `ERROR_MISMATCH`), or `INFRA_ERROR` when the exception type is
+a known infrastructure type, or `UNKNOWN` when neither applies.
 
-### Result
-Only registered markers are used for categorization:
-- Horizontal tags: `find`, `insert`, `update`, `delete`, `aggregate`, `index`, `admin`, `collection_mgmt`
-- Vertical tags: `rbac`, `decimal128`, `collation`, `transactions`, `geospatial`, `text_search`, `validation`, `ttl`
-- Special tags: `smoke`, `slow`
+## Not applicable (unsupported) tests
 
-## Adding New Markers
-
-1. Add the marker to `pytest.ini`:
-   ```ini
-   markers =
-       mynewfeature: Description of my feature
-   ```
-
-2. Use it in your tests:
-   ```python
-   @pytest.mark.mynewfeature
-   def test_something():
-       pass
-   ```
-
-The analyzer will automatically include it in reports - no code changes needed!
-
-## Failure Categorization
-
-Tests are categorized into four types:
-
-1. **PASS**: Test succeeded
-2. **FAIL**: Test failed, feature exists but behaves incorrectly
-3. **UNSUPPORTED**: Feature not implemented (skipped tests)
-4. **INFRA_ERROR**: Infrastructure issue (connection, timeout, etc.)
+Tests deselected at collection because the target lacks a required capability
+(via `requires(...)`) are counted as "unsupported". A sidecar written next to
+the report at collection time (`<report>.deselected.json`) records which
+capability each needed, so the feature tree can explain why an area didn't run.
 
 ## Usage
 
 ### CLI
+
 ```bash
-# Quick analysis
+# Analyze the default report and print a summary
 docdb-analyze
 
-# Custom input/output
-docdb-analyze --input results.json --output report.txt
+# Write a markdown report (for a GitHub step summary)
+docdb-analyze --input results.json --output report.md --format markdown
+
+# Other formats
+docdb-analyze --output report.txt --format text
+docdb-analyze --output analysis.json --format json
 ```
 
 ### Programmatic
-```python
-from result_analyzer import ResultAnalyzer, generate_report
 
-# Create analyzer and run analysis
+```python
+from result_analyzer import ResultAnalyzer, generate_report, print_summary
+
 analyzer = ResultAnalyzer()
 analysis = analyzer.analyze_results("report.json")
 
-# Generate report
-generate_report(analysis, "report.txt", format="text")
+print_summary(analysis)
+generate_report(analysis, "report.md", format="markdown")
 ```
-
-## Maintenance
-
-The heuristic-based approach means:
-- ✅ **No maintenance** for new test markers
-- ✅ **Automatic adaptation** to new patterns
-- ⚠️ **May need updates** if new fixture patterns emerge (e.g., new engine names)
-
-To add a new fixture marker or engine name to exclude, update the filter in `analyzer.py`:
-
-```python
-# Skip fixture markers
-if marker in {"documents", "mynewfixture"}:
-    continue
-    
-# Skip engine names
-if marker in {"documentdb", "mongodb", "mynewengine"}:
-    continue

--- a/documentdb_tests/compatibility/result_analyzer/__init__.py
+++ b/documentdb_tests/compatibility/result_analyzer/__init__.py
@@ -2,7 +2,7 @@
 Result Analyzer for DocumentDB Functional Tests.
 
 This module provides tools for analyzing pytest test results and generating
-reports categorized by feature tags.
+reports grouped by feature (derived from each test's path).
 """
 
 from .analyzer import ResultAnalyzer, categorize_outcome

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -171,6 +171,61 @@ def is_infrastructure_error(test_result: Dict[str, Any]) -> bool:
     return exception_type in INFRA_EXCEPTIONS
 
 
+# Every outcome count we report. pytest-json-report includes a key only when its
+# count is non-zero (an all-pass run has no "failed"/"error"/"skipped" key), so
+# we list the full set here and fill any the run omitted with zero.
+_OUTCOME_COUNT_KEYS = (
+    "collected",
+    "deselected",
+    "total",
+    "passed",
+    "failed",
+    "error",
+    "skipped",
+    "xfailed",
+    "xpassed",
+)
+
+
+def _counts_with_missing_as_zero(native_summary: Dict[str, Any]) -> Dict[str, int]:
+    """
+    Return every outcome count, treating a key the run omitted as zero.
+
+    pytest reports only the outcomes that occurred, so a missing count genuinely
+    means zero. Filling them in lets the rest of the code read each count
+    directly instead of guarding every access.
+    """
+    return {key: native_summary.get(key, 0) for key in _OUTCOME_COUNT_KEYS}
+
+
+def build_reconciliation(native_summary: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build reconciliation figures from pytest-json-report's native summary.
+
+    The native summary already decomposes a run honestly:
+    ``collected = deselected + total`` and
+    ``total = passed + failed + skipped + xfailed + error`` (there is no
+    ``xpassed`` key under ``xfail_strict`` — an unexpected pass is a ``failed``).
+    We surface those counts plus a pass rate whose denominator is only the tests
+    that reached a verdict and could have passed: ``passed + failed + error``.
+    Skipped and xfailed are excluded — a skip never ran and an xfail is a known,
+    expected gap — so neither should move the rate.
+
+    Args:
+        native_summary: The ``summary`` block from the pytest JSON report.
+
+    Returns:
+        Dict of reconciliation counts plus ``pass_rate`` (percent, rounded).
+    """
+    counts = _counts_with_missing_as_zero(native_summary)
+
+    # Only verdict-bearing outcomes count toward the rate; a run with any error
+    # therefore cannot read 100%.
+    denominator = counts["passed"] + counts["failed"] + counts["error"]
+    pass_rate = (counts["passed"] / denominator * 100) if denominator > 0 else 0.0
+    return {**counts, "pass_rate": round(pass_rate, 2)}
+
+
 def load_registered_markers(pytest_ini_path: str = "pytest.ini") -> set:
     """
     Load registered markers from pytest.ini.
@@ -333,6 +388,10 @@ class ResultAnalyzer:
         with open(json_report_path, "r") as f:
             report = json.load(f)
 
+        # Reconciliation is derived from pytest's own summary, which counts
+        # deselected/errored tests that the per-test loop below never sees.
+        reconciliation = build_reconciliation(report.get("summary", {}))
+
         # Initialize counters
         summary: Dict[str, Any] = {
             "total": 0,
@@ -405,4 +464,9 @@ class ResultAnalyzer:
             (summary["passed"] / summary["total"] * 100) if summary["total"] > 0 else 0, 2
         )
 
-        return {"summary": summary, "by_tag": by_tag_with_rates, "tests": tests_details}
+        return {
+            "summary": summary,
+            "by_tag": by_tag_with_rates,
+            "tests": tests_details,
+            "reconciliation": reconciliation,
+        }

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -167,7 +167,9 @@ def extract_skip_reason(test_result: Dict[str, Any]) -> str:
         longrepr = info.get("longrepr", "")
         if not isinstance(longrepr, str):
             continue
-        match = re.search(r"Skipped:\s*(.*?)'\)\s*$", longrepr)
+        # repr double-quotes the reason when it contains an apostrophe;
+        # accept either quote or the reason is lost.
+        match = re.search(r"Skipped:\s*(.*?)['\"]\)\s*$", longrepr)
         if match:
             return match.group(1)
     return ""

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -394,15 +394,8 @@ class ResultAnalyzer:
         Returns:
             Dictionary containing analysis results with structure:
             {
-                "summary": {
-                    "total": int,
-                    "passed": int,
-                    "failed": int,
-                    "skipped": int,
-                    "pass_rate": float
-                },
-                "reconciliation": { ... },  # counts + pass_rate (see build_reconciliation)
-                "by_feature": { ... },      # nested feature tree (see group_by_feature)
+                "reconciliation": { ... }, # counts + pass_rate (see build_reconciliation)
+                "by_feature": { ... },     # nested feature tree (see group_by_feature)
                 "tests": [
                     {
                         "name": str,
@@ -426,34 +419,17 @@ class ResultAnalyzer:
         deselected_nodeids = self._load_deselected(json_report_path)
 
         # Reconciliation is derived from pytest's own summary, which counts
-        # deselected/errored tests that the per-test loop below never sees.
+        # deselected/errored tests that the per-test loop below never sees. It
+        # is the single source of run totals and pass rate.
         reconciliation = build_reconciliation(report.get("summary", {}))
-
-        # Initialize counters
-        summary: Dict[str, Any] = {
-            "total": 0,
-            "passed": 0,
-            "failed": 0,
-            "error": 0,
-            "skipped": 0,
-            "xfailed": 0,
-            "xpassed": 0,
-        }
 
         tests_details = []
 
         # Process each test
         tests = report.get("tests", [])
         for test in tests:
-            summary["total"] += 1
-
             # Categorize the outcome
             test_outcome = categorize_outcome(test)
-
-            # Update summary counters using mapping
-            counter_key = OUTCOME_TO_KEY.get(test_outcome)
-            if counter_key:
-                summary[counter_key] += 1
 
             # Store test details
             test_detail = {
@@ -487,14 +463,8 @@ class ResultAnalyzer:
 
             tests_details.append(test_detail)
 
-        # Calculate overall pass rate
-        summary["pass_rate"] = round(
-            (summary["passed"] / summary["total"] * 100) if summary["total"] > 0 else 0, 2
-        )
-
         return {
-            "summary": summary,
-            "tests": tests_details,
             "reconciliation": reconciliation,
+            "tests": tests_details,
             "by_feature": group_by_feature(tests_details, deselected_nodeids),
         }

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -18,6 +18,7 @@ from documentdb_tests.framework.infra_exceptions import INFRA_EXCEPTION_NAMES as
 OUTCOME_TO_KEY = {
     "PASS": "passed",
     "FAIL": "failed",
+    "ERROR": "error",
     "SKIPPED": "skipped",
     "XFAIL": "xfailed",
     "XPASS": "xpassed",
@@ -29,6 +30,7 @@ class TestOutcome:
 
     PASS = "PASS"
     FAIL = "FAIL"
+    ERROR = "ERROR"
     SKIPPED = "SKIPPED"
     XFAIL = "XFAIL"
     XPASS = "XPASS"
@@ -40,7 +42,8 @@ def categorize_outcome(test_result: Dict[str, Any]) -> str:
 
     Maps pytest outcomes to simple categories:
     - PASS: Test passed
-    - FAIL: Test failed (for any reason)
+    - FAIL: Test failed a verdict (assertion/comparison in the call phase)
+    - ERROR: Test never reached a verdict (a crash in setup or teardown)
     - SKIPPED: Test skipped
     - XFAIL: Test expected to fail and did fail
     - XPASS: Test expected to fail but passed
@@ -49,12 +52,14 @@ def categorize_outcome(test_result: Dict[str, Any]) -> str:
         test_result: Test result dictionary from pytest JSON report
 
     Returns:
-        One of: PASS, FAIL, SKIPPED, XFAIL, XPASS
+        One of: PASS, FAIL, ERROR, SKIPPED, XFAIL, XPASS
     """
     outcome = test_result.get("outcome", "")
 
     if outcome == "passed":
         return TestOutcome.PASS
+    elif outcome == "error":
+        return TestOutcome.ERROR
     elif outcome == "skipped":
         return TestOutcome.SKIPPED
     elif outcome == "xfailed":
@@ -397,13 +402,21 @@ class ResultAnalyzer:
             "total": 0,
             "passed": 0,
             "failed": 0,
+            "error": 0,
             "skipped": 0,
             "xfailed": 0,
             "xpassed": 0,
         }
 
         by_tag: Dict[str, Dict[str, int]] = defaultdict(
-            lambda: {"passed": 0, "failed": 0, "skipped": 0, "xfailed": 0, "xpassed": 0}
+            lambda: {
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+            }
         )
 
         tests_details = []
@@ -437,8 +450,10 @@ class ResultAnalyzer:
                 "tags": tags,
             }
 
-            # Add error information for failed tests
-            if test_outcome == TestOutcome.FAIL:
+            # Add error information for tests that failed or errored. A FAIL
+            # reached a verdict and was wrong; an ERROR crashed before a verdict
+            # (usually in a fixture) - both carry a traceback worth surfacing.
+            if test_outcome in (TestOutcome.FAIL, TestOutcome.ERROR):
                 phase_info = _failing_phase_info(test)
                 test_detail["error"] = phase_info.get("longrepr", "")
                 if is_infrastructure_error(test):

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -144,6 +144,26 @@ def extract_failure_tag(test_result: Dict[str, Any]) -> str:
     return ""
 
 
+def extract_skip_reason(test_result: Dict[str, Any]) -> str:
+    """
+    Extract the reason a test was skipped, from its setup-phase longrepr.
+
+    pytest records a skip as ``('<path>', <lineno>, 'Skipped: <reason>')`` in the
+    setup phase's longrepr. Pull out the reason text.
+
+    Args:
+        test_result: Full test result dict from pytest JSON
+
+    Returns:
+        The reason, or empty string if none is recorded.
+    """
+    longrepr = (test_result.get("setup") or {}).get("longrepr", "")
+    if not isinstance(longrepr, str):
+        return ""
+    match = re.search(r"Skipped:\s*(.*?)'\)\s*$", longrepr)
+    return match.group(1) if match else ""
+
+
 def is_infrastructure_error(test_result: Dict[str, Any]) -> bool:
     """
     Check if error is infrastructure-related based on exception type.
@@ -276,7 +296,9 @@ def feature_path(nodeid: str) -> List[str]:
     return relative.split("/")
 
 
-def group_by_feature(tests: List[Dict[str, Any]]) -> Dict[str, Any]:
+def group_by_feature(
+    tests: List[Dict[str, Any]], deselected: Optional[Dict[str, Dict[str, bool]]] = None
+) -> Dict[str, Any]:
     """
     Aggregate per-test outcomes into a nested tree keyed by feature path.
 
@@ -287,27 +309,42 @@ def group_by_feature(tests: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     Args:
         tests: The per-test detail dicts (each with ``name`` and ``outcome``).
+        deselected: Optional mapping of deselected nodeid -> the requirements the
+            target didn't meet. Deselected tests have no outcome, so they're
+            counted under a separate ``deselected`` tally and their required
+            capability names are collected into each node's ``requires`` set,
+            letting the tree show — and explain — areas not applicable here.
 
     Returns:
-        The root node: ``{"counts": {...}, "children": {component: node, ...}}``.
+        The root node:
+        ``{"counts": {...}, "requires": set(), "children": {component: node}}``.
     """
 
     def _new_node() -> Dict[str, Any]:
-        return {"counts": {key: 0 for key in _PER_TEST_OUTCOME_KEYS}, "children": {}}
+        counts = dict.fromkeys(_PER_TEST_OUTCOME_KEYS, 0)
+        counts["deselected"] = 0
+        return {"counts": counts, "requires": set(), "children": {}}
+
+    def _credit(nodeid: str, counter_key: str, requires: Optional[List[str]] = None) -> None:
+        components = feature_path(nodeid)
+        node = root
+        node["counts"][counter_key] += 1
+        node["requires"].update(requires or [])
+        for component in components:
+            node = node["children"].setdefault(component, _new_node())
+            node["counts"][counter_key] += 1
+            node["requires"].update(requires or [])
 
     root = _new_node()
     for test in tests:
         counter_key = OUTCOME_TO_KEY.get(test.get("outcome", ""))
         if counter_key is None:
             continue
-        components = feature_path(test.get("name", ""))
-        # Credit the count to the root and to every node along the path, so each
+        # Credit the count to the root and every node along the path, so each
         # node's counts include all tests beneath it.
-        node = root
-        node["counts"][counter_key] += 1
-        for component in components:
-            node = node["children"].setdefault(component, _new_node())
-            node["counts"][counter_key] += 1
+        _credit(test.get("name", ""), counter_key)
+    for nodeid, unmet in (deselected or {}).items():
+        _credit(nodeid, "deselected", requires=list(unmet.keys()))
     return root
 
 
@@ -431,6 +468,26 @@ class ResultAnalyzer:
         # Filter to only registered markers
         return [m for m in markers if m in registered_markers]
 
+    @staticmethod
+    def _load_deselected(json_report_path: str) -> Dict[str, Dict[str, bool]]:
+        """
+        Return the report's deselected sidecar: nodeid -> unmet requirements.
+
+        The sidecar (``<report>.deselected.json``) is written at collection time
+        (see conftest); it maps each deselected nodeid to the requirements the
+        target didn't meet. Absent sidecar (older runs, or no deselection) yields
+        an empty mapping.
+        """
+        sidecar = f"{json_report_path}.deselected.json"
+        if not Path(sidecar).exists():
+            return {}
+        try:
+            with open(sidecar) as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError):
+            return {}
+
     def analyze_results(self, json_report_path: str) -> Dict[str, Any]:
         """
         Analyze pytest JSON report and generate categorized results.
@@ -472,6 +529,11 @@ class ResultAnalyzer:
         # Load JSON report
         with open(json_report_path, "r") as f:
             report = json.load(f)
+
+        # Deselected tests are dropped before the run, so they aren't in the
+        # report. A sidecar written at collection time (if present) records which
+        # ones and why, letting the feature tree show areas not applicable here.
+        deselected_nodeids = self._load_deselected(json_report_path)
 
         # Reconciliation is derived from pytest's own summary, which counts
         # deselected/errored tests that the per-test loop below never sees.
@@ -541,6 +603,18 @@ class ResultAnalyzer:
                 else:
                     test_detail["failure_type"] = extract_failure_tag(test) or "UNKNOWN"
 
+            # An xfailed test is a documented incompatibility; carry its reason
+            # (recorded into the report metadata by a conftest hook) so it can be
+            # listed as a known gap.
+            if test_outcome == TestOutcome.XFAIL:
+                metadata = test.get("metadata") or {}
+                test_detail["xfail_reason"] = metadata.get("xfail_reason", "")
+
+            # A skipped test was deliberately not run; carry its reason so the
+            # report can explain why, rather than showing a bare count.
+            if test_outcome == TestOutcome.SKIPPED:
+                test_detail["skip_reason"] = extract_skip_reason(test)
+
             tests_details.append(test_detail)
 
         # Calculate pass rates for each tag
@@ -564,5 +638,5 @@ class ResultAnalyzer:
             "by_tag": by_tag_with_rates,
             "tests": tests_details,
             "reconciliation": reconciliation,
-            "by_feature": group_by_feature(tests_details),
+            "by_feature": group_by_feature(tests_details, deselected_nodeids),
         }

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -2,12 +2,11 @@
 Result analyzer for parsing and categorizing test results.
 
 This module provides functions to analyze pytest JSON output and categorize
-test results by tags and failure types.
+test results by feature (from the test path) and failure type.
 """
 
 import json
 import re
-from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -356,125 +355,14 @@ def group_by_feature(
     return root
 
 
-def load_registered_markers(pytest_ini_path: str = "pytest.ini") -> set:
-    """
-    Load registered markers from pytest.ini.
-
-    Parses the markers section to extract marker names, ensuring we only
-    use markers that are explicitly registered in pytest configuration.
-
-    Args:
-        pytest_ini_path: Path to pytest.ini file (defaults to "pytest.ini")
-
-    Returns:
-        Set of registered marker names
-    """
-    # Check if pytest.ini exists
-    if not Path(pytest_ini_path).exists():
-        return set()
-
-    registered_markers = set()
-
-    try:
-        with open(pytest_ini_path, "r") as f:
-            in_markers_section = False
-
-            for line in f:
-                # Check if we're entering the markers section
-                if line.strip() == "markers =":
-                    in_markers_section = True
-                    continue
-
-                if in_markers_section:
-                    # Marker lines are indented, config keys are not
-                    if line and not line[0].isspace():
-                        # Non-indented line means we left the markers section
-                        break
-
-                    # Parse indented marker lines like "    find: Find operation tests"
-                    match = re.match(r"^\s+([a-zA-Z0-9_]+):", line)
-                    if match:
-                        registered_markers.add(match.group(1))
-
-    except Exception:
-        # If parsing fails, return empty set
-        pass
-
-    return registered_markers
-
-
 class ResultAnalyzer:
     """
     Analyzer for pytest JSON test results.
 
-    This class provides stateful analysis with configurable pytest.ini path,
-    making it easier to test and use in multiple contexts.
-
-    Args:
-        pytest_ini_path: Path to pytest.ini file for marker configuration
-
     Example:
-        analyzer = ResultAnalyzer("pytest.ini")
+        analyzer = ResultAnalyzer()
         results = analyzer.analyze_results("report.json")
     """
-
-    _DEFAULT_PYTEST_INI = str(Path(__file__).resolve().parent.parent.parent / "pytest.ini")
-
-    def __init__(self, pytest_ini_path: str = _DEFAULT_PYTEST_INI):
-        """
-        Initialize the result analyzer.
-
-        Args:
-            pytest_ini_path: Path to pytest.ini file (default: documentdb_tests/pytest.ini)
-        """
-        self.pytest_ini_path = pytest_ini_path
-        self._markers_cache: Optional[set] = None
-
-    def _get_registered_markers(self) -> set:
-        """
-        Get registered markers (cached per instance).
-
-        Returns:
-            Set of registered marker names
-        """
-        if self._markers_cache is None:
-            self._markers_cache = load_registered_markers(self.pytest_ini_path)
-        return self._markers_cache
-
-    def extract_markers(self, test_result: Dict[str, Any]) -> List[str]:
-        """
-        Extract pytest markers (tags) from a test result.
-
-        Uses registered markers from pytest.ini as an allow list.
-        This ensures only intentional test categorization markers are included,
-        avoiding brittle heuristics that could break with future pytest versions.
-
-        Args:
-            test_result: Test result dictionary from pytest JSON report
-
-        Returns:
-            List of marker names that match registered markers from pytest.ini
-        """
-        registered_markers = self._get_registered_markers()
-
-        markers = []
-
-        # Extract from keywords
-        keywords = test_result.get("keywords", [])
-        if isinstance(keywords, list):
-            markers.extend(keywords)
-
-        # Extract from markers field if present
-        test_markers = test_result.get("markers", [])
-        if isinstance(test_markers, list):
-            for marker in test_markers:
-                if isinstance(marker, dict):
-                    markers.append(marker.get("name", ""))
-                else:
-                    markers.append(str(marker))
-
-        # Filter to only registered markers
-        return [m for m in markers if m in registered_markers]
 
     @staticmethod
     def _load_deselected(json_report_path: str) -> Dict[str, Dict[str, bool]]:
@@ -513,23 +401,17 @@ class ResultAnalyzer:
                     "skipped": int,
                     "pass_rate": float
                 },
-                "by_tag": {
-                    "tag_name": {
-                        "passed": int,
-                        "failed": int,
-                        "skipped": int,
-                        "total": int,
-                        "pass_rate": float
-                    }
-                },
+                "reconciliation": { ... },  # counts + pass_rate (see build_reconciliation)
+                "by_feature": { ... },      # nested feature tree (see group_by_feature)
                 "tests": [
                     {
                         "name": str,
                         "outcome": str,
                         "duration": float,
-                        "tags": List[str],
-                        "error": str (optional, present for failed tests),
-                        "is_infra_error": bool (optional, present for failed tests)
+                        "error": str (optional, present for failed/errored tests),
+                        "failure_type": str (optional, present for failed/errored tests),
+                        "xfail_reason": str (optional, present for xfailed tests),
+                        "skip_reason": str (optional, present for skipped tests)
                     }
                 ]
             }
@@ -558,17 +440,6 @@ class ResultAnalyzer:
             "xpassed": 0,
         }
 
-        by_tag: Dict[str, Dict[str, int]] = defaultdict(
-            lambda: {
-                "passed": 0,
-                "failed": 0,
-                "error": 0,
-                "skipped": 0,
-                "xfailed": 0,
-                "xpassed": 0,
-            }
-        )
-
         tests_details = []
 
         # Process each test
@@ -579,25 +450,16 @@ class ResultAnalyzer:
             # Categorize the outcome
             test_outcome = categorize_outcome(test)
 
-            # Extract tags using instance method
-            tags = self.extract_markers(test)
-
             # Update summary counters using mapping
             counter_key = OUTCOME_TO_KEY.get(test_outcome)
             if counter_key:
                 summary[counter_key] += 1
-
-            # Update tag-specific counters
-            if counter_key:
-                for tag in tags:
-                    by_tag[tag][counter_key] += 1
 
             # Store test details
             test_detail = {
                 "name": test.get("nodeid", ""),
                 "outcome": test_outcome,
                 "duration": test.get("duration", 0),
-                "tags": tags,
             }
 
             # Add error information for tests that failed or errored. A FAIL
@@ -625,17 +487,6 @@ class ResultAnalyzer:
 
             tests_details.append(test_detail)
 
-        # Calculate pass rates for each tag
-        # Note: 'total' includes all tests (passed + failed + skipped)
-        # Pass rate is calculated as: passed / total
-        # This means skipped tests lower the pass rate, which is intentional
-        by_tag_with_rates = {}
-        for tag, counts in by_tag.items():
-            total = counts["passed"] + counts["failed"] + counts["skipped"]
-            pass_rate = (counts["passed"] / total * 100) if total > 0 else 0
-
-            by_tag_with_rates[tag] = {**counts, "total": total, "pass_rate": round(pass_rate, 2)}
-
         # Calculate overall pass rate
         summary["pass_rate"] = round(
             (summary["passed"] / summary["total"] * 100) if summary["total"] > 0 else 0, 2
@@ -643,7 +494,6 @@ class ResultAnalyzer:
 
         return {
             "summary": summary,
-            "by_tag": by_tag_with_rates,
             "tests": tests_details,
             "reconciliation": reconciliation,
             "by_feature": group_by_feature(tests_details, deselected_nodeids),

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -132,9 +132,11 @@ def extract_failure_tag(test_result: Dict[str, Any]) -> str:
     crash_info = phase_info.get("crash", {})
     crash_message = crash_info.get("message", "")
 
-    # Detect strict XPASS from longrepr
+    # Detect strict XPASS from longrepr. Match anywhere in the text: under
+    # xdist the worker prepends a banner line ("[gw2] linux -- ..."), so the
+    # marker is not necessarily at the start.
     longrepr = phase_info.get("longrepr", "")
-    if isinstance(longrepr, str) and longrepr.startswith("[XPASS(strict)]"):
+    if isinstance(longrepr, str) and "[XPASS(strict)]" in longrepr:
         return "XPASS_STRICT"
 
     match = re.search(r"\[([A-Z_]+)\]", crash_message)

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -285,7 +285,8 @@ def build_reconciliation(native_summary: Dict[str, Any]) -> Dict[str, Any]:
 # The test root under which the feature taxonomy begins. A nodeid looks like
 # "documentdb_tests/compatibility/tests/core/operator/.../test_x.py::test_y";
 # everything after this prefix is the feature path (core, operator, ...).
-_TESTS_ROOT = "tests/"
+# Anchored to a path-component boundary so "documentdb_tests/" can't match.
+_TESTS_ROOT_PATTERN = re.compile(r"(?:^|/)tests/")
 
 
 def feature_path(nodeid: str) -> List[str]:
@@ -308,10 +309,10 @@ def feature_path(nodeid: str) -> List[str]:
         the root isn't found.
     """
     path = nodeid.split("::", 1)[0]
-    root_index = path.rfind(_TESTS_ROOT)
-    if root_index == -1:
+    matches = list(_TESTS_ROOT_PATTERN.finditer(path))
+    if not matches:
         return []
-    relative = path[root_index + len(_TESTS_ROOT) :]
+    relative = path[matches[-1].end() :]
     return relative.split("/")
 
 

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -85,13 +85,38 @@ def extract_exception_type(crash_message: str) -> str:
     return ""
 
 
+# Phases pytest reports for a test, in execution order. A test can fail in any of
+# them: a fixture crash surfaces in ``setup``, an assertion in ``call``, a
+# fixture-teardown error in ``teardown``.
+_PHASES = ("call", "setup", "teardown")
+
+
+def _failing_phase_info(test_result: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Return the phase dict that carries the failure, preferring ``call``.
+
+    A normal test failure lives in ``call``, but an errored test has no ``call``
+    phase at all — its crash/longrepr is under ``setup`` (or ``teardown``).
+    Reading only ``call`` would miss those entirely, so fall back across phases.
+    """
+    # Prefer an explicitly failed phase; otherwise the first phase present.
+    for phase in _PHASES:
+        info = test_result.get(phase)
+        if isinstance(info, dict) and info.get("outcome") == "failed":
+            return info
+    for phase in _PHASES:
+        info = test_result.get(phase)
+        if isinstance(info, dict):
+            return info
+    return {}
+
+
 def extract_failure_tag(test_result: Dict[str, Any]) -> str:
     """
-    Extract failure tag (e.g. RESULT_MISMATCH) from assertion message.
+    Extract a failure tag (e.g. RESULT_MISMATCH) from an assertion message.
 
-    The framework assertions prefix errors with tags like:
-    [RESULT_MISMATCH], [UNEXPECTED_ERROR], [UNEXPECTED_SUCCESS],
-    [ERROR_MISMATCH], [TEST_EXCEPTION]
+    Framework assertions prefix errors with a bracketed tag; this returns the
+    first one found, whatever it is, so new tags need no change here.
 
     Args:
         test_result: Full test result dict from pytest JSON
@@ -99,13 +124,13 @@ def extract_failure_tag(test_result: Dict[str, Any]) -> str:
     Returns:
         Tag string without brackets, or empty string if not found
     """
-    call_info = test_result.get("call", {})
-    crash_info = call_info.get("crash", {})
+    phase_info = _failing_phase_info(test_result)
+    crash_info = phase_info.get("crash", {})
     crash_message = crash_info.get("message", "")
 
     # Detect strict XPASS from longrepr
-    longrepr = call_info.get("longrepr", "")
-    if longrepr.startswith("[XPASS(strict)]"):
+    longrepr = phase_info.get("longrepr", "")
+    if isinstance(longrepr, str) and longrepr.startswith("[XPASS(strict)]"):
         return "XPASS_STRICT"
 
     match = re.search(r"\[([A-Z_]+)\]", crash_message)
@@ -128,9 +153,9 @@ def is_infrastructure_error(test_result: Dict[str, Any]) -> bool:
     Returns:
         True if error is infrastructure-related, False otherwise
     """
-    # Get the crash info from call
-    call_info = test_result.get("call", {})
-    crash_info = call_info.get("crash", {})
+    # Get the crash info from the failing phase (setup for errored tests)
+    phase_info = _failing_phase_info(test_result)
+    crash_info = phase_info.get("crash", {})
     crash_message = crash_info.get("message", "")
 
     if not crash_message:
@@ -355,8 +380,8 @@ class ResultAnalyzer:
 
             # Add error information for failed tests
             if test_outcome == TestOutcome.FAIL:
-                call_info = test.get("call", {})
-                test_detail["error"] = call_info.get("longrepr", "")
+                phase_info = _failing_phase_info(test)
+                test_detail["error"] = phase_info.get("longrepr", "")
                 if is_infrastructure_error(test):
                     test_detail["failure_type"] = "INFRA_ERROR"
                 else:

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -296,10 +296,10 @@ def feature_path(nodeid: str) -> List[str]:
         the root isn't found.
     """
     path = nodeid.split("::", 1)[0]
-    marker = path.rfind(_TESTS_ROOT)
-    if marker == -1:
+    root_index = path.rfind(_TESTS_ROOT)
+    if root_index == -1:
         return []
-    relative = path[marker + len(_TESTS_ROOT) :]
+    relative = path[root_index + len(_TESTS_ROOT) :]
     return relative.split("/")
 
 

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -145,10 +145,12 @@ def extract_failure_tag(test_result: Dict[str, Any]) -> str:
 
 def extract_skip_reason(test_result: Dict[str, Any]) -> str:
     """
-    Extract the reason a test was skipped, from its setup-phase longrepr.
+    Extract the reason a test was skipped, from the phase that skipped it.
 
     pytest records a skip as ``('<path>', <lineno>, 'Skipped: <reason>')`` in the
-    setup phase's longrepr. Pull out the reason text.
+    longrepr of whichever phase raised it: ``setup`` for a marker or a fixture's
+    skip, ``call`` for a runtime ``pytest.skip()`` inside the test body. Reading
+    only one phase would silently lose the other's reason.
 
     Args:
         test_result: Full test result dict from pytest JSON
@@ -156,11 +158,17 @@ def extract_skip_reason(test_result: Dict[str, Any]) -> str:
     Returns:
         The reason, or empty string if none is recorded.
     """
-    longrepr = (test_result.get("setup") or {}).get("longrepr", "")
-    if not isinstance(longrepr, str):
-        return ""
-    match = re.search(r"Skipped:\s*(.*?)'\)\s*$", longrepr)
-    return match.group(1) if match else ""
+    for phase in _PHASES:
+        info = test_result.get(phase)
+        if not isinstance(info, dict) or info.get("outcome") != "skipped":
+            continue
+        longrepr = info.get("longrepr", "")
+        if not isinstance(longrepr, str):
+            continue
+        match = re.search(r"Skipped:\s*(.*?)'\)\s*$", longrepr)
+        if match:
+            return match.group(1)
+    return ""
 
 
 def is_infrastructure_error(test_result: Dict[str, Any]) -> bool:

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -191,6 +191,18 @@ _OUTCOME_COUNT_KEYS = (
     "xpassed",
 )
 
+# Per-test outcome buckets (the subset of the above that a single test can land
+# in). Used when aggregating tests, where run-level totals like "collected" or
+# "deselected" have no meaning.
+_PER_TEST_OUTCOME_KEYS = (
+    "passed",
+    "failed",
+    "error",
+    "skipped",
+    "xfailed",
+    "xpassed",
+)
+
 
 def _counts_with_missing_as_zero(native_summary: Dict[str, Any]) -> Dict[str, int]:
     """
@@ -229,6 +241,74 @@ def build_reconciliation(native_summary: Dict[str, Any]) -> Dict[str, Any]:
     denominator = counts["passed"] + counts["failed"] + counts["error"]
     pass_rate = (counts["passed"] / denominator * 100) if denominator > 0 else 0.0
     return {**counts, "pass_rate": round(pass_rate, 2)}
+
+
+# The test root under which the feature taxonomy begins. A nodeid looks like
+# "documentdb_tests/compatibility/tests/core/operator/.../test_x.py::test_y";
+# everything after this prefix is the feature path (core, operator, ...).
+_TESTS_ROOT = "tests/"
+
+
+def feature_path(nodeid: str) -> List[str]:
+    """
+    Return the feature path components for a test, from its nodeid.
+
+    The directory tree under ``tests/`` *is* the feature taxonomy
+    (e.g. ``core/operator/expressions/arithmetic/add``), so the path components
+    are the grouping tiers — area first, then successively narrower categories,
+    down to the test file itself as the deepest tier (files group related cases,
+    e.g. ``subtract/test_subtract_errors.py``). The tree is ragged, so callers
+    must not assume a fixed depth. The ``::test`` selector is dropped — individual
+    test cases are the leaves shown elsewhere, not tree tiers.
+
+    Args:
+        nodeid: A pytest node id.
+
+    Returns:
+        Ordered path components (directories then the file), or an empty list if
+        the root isn't found.
+    """
+    path = nodeid.split("::", 1)[0]
+    marker = path.rfind(_TESTS_ROOT)
+    if marker == -1:
+        return []
+    relative = path[marker + len(_TESTS_ROOT) :]
+    return relative.split("/")
+
+
+def group_by_feature(tests: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Aggregate per-test outcomes into a nested tree keyed by feature path.
+
+    Each node holds its own aggregated outcome counts (summed over every test
+    beneath it) and a ``children`` map of the next path component to a child
+    node. A node is a leaf when tests live directly at its path; because the
+    tree is ragged, leaves occur at varying depths.
+
+    Args:
+        tests: The per-test detail dicts (each with ``name`` and ``outcome``).
+
+    Returns:
+        The root node: ``{"counts": {...}, "children": {component: node, ...}}``.
+    """
+
+    def _new_node() -> Dict[str, Any]:
+        return {"counts": {key: 0 for key in _PER_TEST_OUTCOME_KEYS}, "children": {}}
+
+    root = _new_node()
+    for test in tests:
+        counter_key = OUTCOME_TO_KEY.get(test.get("outcome", ""))
+        if counter_key is None:
+            continue
+        components = feature_path(test.get("name", ""))
+        # Credit the count to the root and to every node along the path, so each
+        # node's counts include all tests beneath it.
+        node = root
+        node["counts"][counter_key] += 1
+        for component in components:
+            node = node["children"].setdefault(component, _new_node())
+            node["counts"][counter_key] += 1
+    return root
 
 
 def load_registered_markers(pytest_ini_path: str = "pytest.ini") -> set:
@@ -484,4 +564,5 @@ class ResultAnalyzer:
             "by_tag": by_tag_with_rates,
             "tests": tests_details,
             "reconciliation": reconciliation,
+            "by_feature": group_by_feature(tests_details),
         }

--- a/documentdb_tests/compatibility/result_analyzer/analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/analyzer.py
@@ -256,6 +256,14 @@ def build_reconciliation(native_summary: Dict[str, Any]) -> Dict[str, Any]:
     """
     counts = _counts_with_missing_as_zero(native_summary)
 
+    # Deselected tests are those collected but not run. pytest doesn't always
+    # record a ``deselected`` count, so derive it from collected - total to keep
+    # the decomposition honest: collected = deselected + total, always.
+    collected = counts["collected"]
+    total = counts["total"]
+    if collected >= total:
+        counts["deselected"] = collected - total
+
     # Only verdict-bearing outcomes count toward the rate; a run with any error
     # therefore cannot read 100%.
     denominator = counts["passed"] + counts["failed"] + counts["error"]

--- a/documentdb_tests/compatibility/result_analyzer/cli.py
+++ b/documentdb_tests/compatibility/result_analyzer/cli.py
@@ -96,7 +96,8 @@ Examples:
                 print(f"\nReport saved to: {args.output}")
 
         # Return exit code based on test results
-        if analysis["summary"]["failed"] > 0:
+        reconciliation = analysis["reconciliation"]
+        if reconciliation["failed"] > 0 or reconciliation["error"] > 0:
             return 1
         return 0
 

--- a/documentdb_tests/compatibility/result_analyzer/cli.py
+++ b/documentdb_tests/compatibility/result_analyzer/cli.py
@@ -51,9 +51,9 @@ Examples:
     parser.add_argument(
         "-f",
         "--format",
-        choices=["text", "json"],
+        choices=["text", "json", "markdown"],
         default="text",
-        help="Output format: text or json (default: text)",
+        help="Output format: text, json, or markdown (default: text)",
     )
 
     parser.add_argument(

--- a/documentdb_tests/compatibility/result_analyzer/cli.py
+++ b/documentdb_tests/compatibility/result_analyzer/cli.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 from .analyzer import ResultAnalyzer
+from .report_content import VERDICT_PASS, determine_verdict
 from .report_generator import generate_report, print_summary
 
 
@@ -98,11 +99,10 @@ Examples:
             if not args.quiet:
                 print(f"\nReport saved to: {args.output}")
 
-        # Return exit code based on test results
-        reconciliation = analysis["reconciliation"]
-        if reconciliation["failed"] > 0 or reconciliation["error"] > 0:
-            return 1
-        return 0
+        # Exit with the report's own verdict, which also fails on raw xpasses
+        # and empty runs.
+        verdict, _ = determine_verdict(analysis["reconciliation"])
+        return 0 if verdict == VERDICT_PASS else 1
 
     except Exception as e:
         print(f"Error analyzing results: {e}", file=sys.stderr)

--- a/documentdb_tests/compatibility/result_analyzer/cli.py
+++ b/documentdb_tests/compatibility/result_analyzer/cli.py
@@ -29,6 +29,9 @@ Examples:
   # Generate text report
   %(prog)s --output report.txt --format text
 
+  # Generate a markdown report (for a GitHub step summary)
+  %(prog)s --output report.md --format markdown
+
   # Generate JSON analysis
   %(prog)s --output analysis.json --format json
 

--- a/documentdb_tests/compatibility/result_analyzer/render_json.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_json.py
@@ -1,0 +1,21 @@
+"""
+JSON rendering.
+
+Serializes the analysis as machine-readable JSON, for ad-hoc tooling or
+debugging. Presentation only; a peer of the text renderer.
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+def render(analysis: Dict[str, Any]) -> str:
+    """Render the analysis as a JSON document."""
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "summary": analysis["summary"],
+        "by_tag": analysis["by_tag"],
+        "tests": analysis["tests"],
+    }
+    return json.dumps(report, indent=2)

--- a/documentdb_tests/compatibility/result_analyzer/render_json.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_json.py
@@ -14,7 +14,7 @@ def render(analysis: Dict[str, Any]) -> str:
     """Render the analysis as a JSON document."""
     report = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "summary": analysis["summary"],
+        "reconciliation": analysis["reconciliation"],
         "tests": analysis["tests"],
     }
     return json.dumps(report, indent=2)

--- a/documentdb_tests/compatibility/result_analyzer/render_json.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_json.py
@@ -15,7 +15,6 @@ def render(analysis: Dict[str, Any]) -> str:
     report = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "summary": analysis["summary"],
-        "by_tag": analysis["by_tag"],
         "tests": analysis["tests"],
     }
     return json.dumps(report, indent=2)

--- a/documentdb_tests/compatibility/result_analyzer/render_markdown.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_markdown.py
@@ -8,7 +8,13 @@ Presentation only; no selection logic lives here.
 
 from typing import Any, Dict, List
 
-from .report_content import VERDICT_PASS, determine_verdict
+from .report_content import (
+    NEEDS_ATTENTION_CAP,
+    VERDICT_PASS,
+    cap_items,
+    determine_verdict,
+    group_needs_attention,
+)
 
 
 def _verdict_heading(analysis: Dict[str, Any]) -> str:
@@ -56,8 +62,55 @@ def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
     return lines
 
 
+def _needs_attention_lines(analysis: Dict[str, Any]) -> List[str]:
+    """
+    The failures and errors a human must act on, grouped by failure type.
+
+    Each test is a collapsible ``<details>`` whose summary is the one-line
+    identity and whose body is the real traceback, so the section stays scannable
+    while the full detail is one click away. A mass failure is capped so it can't
+    bury the report or exceed the step-summary size limit.
+    """
+    grouped = group_needs_attention(analysis)
+    if not grouped:
+        return []
+
+    total = sum(len(v) for v in grouped.values())
+    lines = ["", f"### Needs attention ({total})", ""]
+
+    for failure_type in sorted(grouped):
+        tests = grouped[failure_type]
+        lines.append(f"#### {failure_type} ({len(tests)})")
+        lines.append("")
+        shown, omitted = cap_items(tests)
+        for test in shown:
+            lines.extend(_failure_details(test))
+        if omitted:
+            lines.append(f"_… and {omitted} more not shown (cap {NEEDS_ATTENTION_CAP})._")
+            lines.append("")
+    return lines
+
+
+def _failure_details(test: Dict[str, Any]) -> List[str]:
+    """One collapsible entry: summary line + traceback in a code block."""
+    name = test.get("name", "")
+    outcome = test.get("outcome", "")
+    traceback = test.get("error") or "(no traceback captured)"
+    return [
+        "<details>",
+        f"<summary>{outcome}: <code>{name}</code></summary>",
+        "",
+        "```",
+        traceback.rstrip(),
+        "```",
+        "</details>",
+        "",
+    ]
+
+
 def render(analysis: Dict[str, Any]) -> str:
     """Render the full markdown report body."""
     lines = [_verdict_heading(analysis), ""]
     lines.extend(_breakdown_lines(analysis.get("reconciliation", {})))
+    lines.extend(_needs_attention_lines(analysis))
     return "\n".join(lines) + "\n"

--- a/documentdb_tests/compatibility/result_analyzer/render_markdown.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_markdown.py
@@ -1,0 +1,63 @@
+"""
+Markdown rendering for the GitHub step summary.
+
+Consumes the format-agnostic report content and draws it as GitHub-flavored
+markdown (headings, tables, and — in later sections — collapsible details).
+Presentation only; no selection logic lives here.
+"""
+
+from typing import Any, Dict, List
+
+from .report_content import VERDICT_PASS, determine_verdict
+
+
+def _verdict_heading(analysis: Dict[str, Any]) -> str:
+    verdict, reason = determine_verdict(analysis.get("reconciliation", {}))
+    icon = "✅" if verdict == VERDICT_PASS else "❌"
+    heading = f"## {icon} {verdict}"
+    if reason:
+        heading += f" — {reason}"
+    return heading
+
+
+def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
+    """
+    The run breakdown table.
+
+    Shows how the run decomposes — collected into deselected vs executed, and
+    executed into each outcome — so the pass rate is never read without the
+    context that explains it (e.g. an all-error run reads 0 passed, not "0% of a
+    real suite").
+    """
+    r = reconciliation
+    passed = r.get("passed", 0)
+    failed = r.get("failed", 0)
+    errored = r.get("error", 0)
+    counted = passed + failed + errored
+
+    lines = ["### Breakdown", ""]
+    lines.append("| Outcome | Count |")
+    lines.append("|---|--:|")
+    lines.append(f"| Collected | {r.get('collected', 0)} |")
+    lines.append(f"| \u2003Not applicable (deselected) | {r.get('deselected', 0)} |")
+    lines.append(f"| \u2003Executed | {r.get('total', 0)} |")
+    lines.append(f"| \u2003\u2003Passed | {passed} |")
+    lines.append(f"| \u2003\u2003Failed | {failed} |")
+    lines.append(f"| \u2003\u2003Errored | {errored} |")
+    lines.append(f"| \u2003\u2003Skipped | {r.get('skipped', 0)} |")
+    lines.append(f"| \u2003\u2003Known gaps (xfailed) | {r.get('xfailed', 0)} |")
+    if r.get("xpassed", 0):
+        lines.append(f"| \u2003\u2003Unexpected passes (xpassed) | {r.get('xpassed', 0)} |")
+    lines.append("")
+    lines.append(
+        f"**Pass rate: {r.get('pass_rate', 0)}%** — {passed} of {counted} passed "
+        "(skipped and known gaps excluded)"
+    )
+    return lines
+
+
+def render(analysis: Dict[str, Any]) -> str:
+    """Render the full markdown report body."""
+    lines = [_verdict_heading(analysis), ""]
+    lines.extend(_breakdown_lines(analysis.get("reconciliation", {})))
+    return "\n".join(lines) + "\n"

--- a/documentdb_tests/compatibility/result_analyzer/render_markdown.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_markdown.py
@@ -1,8 +1,8 @@
 """
 Markdown rendering for the GitHub step summary.
 
-Consumes the format-agnostic report content and draws it as GitHub-flavored
-markdown (headings, tables, and — in later sections — collapsible details).
+Consumes the format-agnostic report content and renders it as GitHub-flavored
+markdown (headings, tables, and - in later sections - collapsible details).
 Presentation only; no selection logic lives here.
 """
 
@@ -14,6 +14,9 @@ from .report_content import (
     cap_items,
     determine_verdict,
     group_needs_attention,
+    known_gaps,
+    pass_rate,
+    skipped_tests,
 )
 
 
@@ -22,7 +25,7 @@ def _verdict_heading(analysis: Dict[str, Any]) -> str:
     icon = "✅" if verdict == VERDICT_PASS else "❌"
     heading = f"## {icon} {verdict}"
     if reason:
-        heading += f" — {reason}"
+        heading += f" - {reason}"
     return heading
 
 
@@ -30,8 +33,8 @@ def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
     """
     The run breakdown table.
 
-    Shows how the run decomposes — collected into deselected vs executed, and
-    executed into each outcome — so the pass rate is never read without the
+    Shows how the run decomposes - collected into deselected vs executed, and
+    executed into each outcome - so the pass rate is never read without the
     context that explains it (e.g. an all-error run reads 0 passed, not "0% of a
     real suite").
     """
@@ -45,7 +48,7 @@ def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
     lines.append("| Outcome | Count |")
     lines.append("|---|--:|")
     lines.append(f"| Collected | {r.get('collected', 0)} |")
-    lines.append(f"| \u2003Not applicable (deselected) | {r.get('deselected', 0)} |")
+    lines.append(f"| \u2003Unsupported (deselected) | {r.get('deselected', 0)} |")
     lines.append(f"| \u2003Executed | {r.get('total', 0)} |")
     lines.append(f"| \u2003\u2003Passed | {passed} |")
     lines.append(f"| \u2003\u2003Failed | {failed} |")
@@ -56,7 +59,7 @@ def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
         lines.append(f"| \u2003\u2003Unexpected passes (xpassed) | {r.get('xpassed', 0)} |")
     lines.append("")
     lines.append(
-        f"**Pass rate: {r.get('pass_rate', 0)}%** — {passed} of {counted} passed "
+        f"**Pass rate: {pass_rate(r)}** - {passed} of {counted} passed "
         "(skipped and known gaps excluded)"
     )
     return lines
@@ -86,7 +89,7 @@ def _needs_attention_lines(analysis: Dict[str, Any]) -> List[str]:
         for test in shown:
             lines.extend(_failure_details(test))
         if omitted:
-            lines.append(f"_… and {omitted} more not shown (cap {NEEDS_ATTENTION_CAP})._")
+            lines.append(f"_... and {omitted} more not shown (cap {NEEDS_ATTENTION_CAP})._")
             lines.append("")
     return lines
 
@@ -108,9 +111,201 @@ def _failure_details(test: Dict[str, Any]) -> List[str]:
     ]
 
 
+def _known_gaps_lines(analysis: Dict[str, Any]) -> List[str]:
+    """
+    Documented incompatibilities (xfailed), collapsed by default.
+
+    These are expected gaps, not regressions, so they're tucked behind a
+    ``<details>`` - out of the way for the common reader, but available as a
+    plain-English catalogue of what doesn't work and why.
+    """
+    gaps = known_gaps(analysis)
+    if not gaps:
+        return []
+
+    lines = ["", "<details>", f"<summary><b>Known gaps ({len(gaps)})</b></summary>", ""]
+    lines.append("| Test | Reason |")
+    lines.append("|---|---|")
+    for gap in gaps:
+        reason = gap["reason"] or "-"
+        lines.append(f"| `{gap['name']}` | {reason} |")
+    lines.append("")
+    lines.append("</details>")
+    return lines
+
+
+def _skipped_lines(analysis: Dict[str, Any]) -> List[str]:
+    """
+    Skipped tests with reasons, collapsed by default.
+
+    Explains why tests didn't run (e.g. not applicable to this target), mirroring
+    known gaps — out of the way behind a ``<details>`` but answerable.
+    """
+    skipped = skipped_tests(analysis)
+    if not skipped:
+        return []
+
+    lines = ["", "<details>", f"<summary><b>Skipped ({len(skipped)})</b></summary>", ""]
+    lines.append("| Test | Reason |")
+    lines.append("|---|---|")
+    for test in skipped:
+        reason = test["reason"] or "-"
+        lines.append(f"| `{test['name']}` | {reason} |")
+    lines.append("")
+    lines.append("</details>")
+    return lines
+
+
+def _feature_status(counts: Dict[str, int]) -> str:
+    """
+    Status icon for a feature node.
+
+    - red if anything failed or errored
+    - blank circle if nothing ran at all (all deselected / not applicable)
+    - blank circle if nothing actually *passed* either (only skipped/xfailed) —
+      a green check would wrongly imply success where nothing was verified
+    - green only when something passed and nothing failed
+    """
+    if counts.get("failed", 0) or counts.get("error", 0):
+        return "❌"
+    if counts.get("passed", 0) == 0:
+        return "⚪"
+    return "✅"
+
+
+def _feature_summary(counts: Dict[str, int]) -> str:
+    """Concise one-line breakdown for a collapsed node: only non-zero buckets."""
+    labels = [
+        ("passed", "passed"),
+        ("failed", "failed"),
+        ("error", "errored"),
+        ("xfailed", "known gaps"),
+        ("skipped", "skipped"),
+        ("deselected", "unsupported"),
+    ]
+    parts = [f"{counts.get(key, 0)} {label}" for key, label in labels if counts.get(key, 0)]
+    return ", ".join(parts) if parts else "no tests"
+
+
+def _unsupported_cell(child: Dict[str, Any], status: str) -> str:
+    """
+    The Unsupported-count cell, with a ``needs: <caps>`` note only on a not-run (⚪) row.
+
+    A test is unsupported when the target lacks a capability it requires, so it
+    was deselected at collection. The note explains which capability was missing.
+    On a passing or failing parent that merely contains some unsupported tests the
+    note would be noise — the row's real story is its passes/failures — so there
+    the cell is just the count.
+    """
+    count = child["counts"].get("deselected", 0)
+    if status != "⚪" or not count:
+        return str(count)
+    requires = sorted(child.get("requires", []))
+    return f"{count} <sub>needs: {', '.join(requires)}</sub>" if requires else str(count)
+
+
+def _children_table(node: Dict[str, Any]) -> List[str]:
+    """
+    An aligned table of every direct child of ``node`` — folders and files — with
+    each one's totals, so a reader can scan a level's rollups at a glance.
+
+    Folders are marked with a trailing ``/`` (and are also expandable below via
+    ``<details>``); files have no slash. This keeps the parent totals visible in
+    the table while still distinguishing the two, and folders sort before files
+    so they aren't interleaved.
+
+    Every test lands in exactly one column — Passed, Failed, Errored, Known gaps
+    (xfailed), Skipped, or Unsupported (deselected because the target lacks a
+    required capability) — so each row reconciles with no hidden "missing" tests.
+    """
+    children = node.get("children", {})
+    # Folders first, then files; each group alphabetical.
+    folders = [n for n in sorted(children) if children[n].get("children")]
+    files = [n for n in sorted(children) if not children[n].get("children")]
+    ordered = folders + files
+    if not ordered:
+        return []
+
+    lines = [
+        "| | Feature | Passed | Failed | Errored | Known gaps | Skipped | Unsupported |",
+        "|--|--|--:|--:|--:|--:|--:|--:|",
+    ]
+    for name in ordered:
+        child = children[name]
+        c = child["counts"]
+        status = _feature_status(c)
+        # Trailing slash marks a folder (also expandable below); files have none.
+        label = f"{name}/" if child.get("children") else name
+        lines.append(
+            f"| {status} | {label} | "
+            f"{c.get('passed', 0)} | {c.get('failed', 0)} | {c.get('error', 0)} | "
+            f"{c.get('xfailed', 0)} | {c.get('skipped', 0)} | "
+            f"{_unsupported_cell(child, status)} |"
+        )
+    return lines
+
+
+def _feature_nodes(node: Dict[str, Any]) -> List[str]:
+    """
+    Render a node's children table (folders + files with totals), then a
+    collapsible ``<details>`` per subfolder to drill in.
+
+    The table shows every child's rollup at this level; folders (marked with a
+    trailing ``/``) additionally expand below. The full tree is emitted — passing
+    branches included — because it all lives behind collapsed ``<details>``, so
+    showing everything costs the reader nothing. Nesting uses ``<ul><li>`` for a
+    clear, unshaded indentation boundary.
+    """
+    children = node.get("children", {})
+    lines = _children_table(node)
+    if lines:
+        lines.append("")
+
+    for name in sorted(children):
+        child = children[name]
+        if child.get("children"):
+            c = child["counts"]
+            lines.append("<details>")
+            lines.append(
+                f"<summary>{_feature_status(c)} <b>{name}/</b> — "
+                f"{_feature_summary(c)}</summary>"
+            )
+            lines.append("<ul><li>")
+            lines.append("")
+            lines.extend(_feature_nodes(child))
+            lines.append("")
+            lines.append("</li></ul>")
+            lines.append("</details>")
+            lines.append("")
+    return lines
+
+
+def _feature_breakdown_lines(analysis: Dict[str, Any]) -> List[str]:
+    """
+    Per-feature results as a collapsible tree of aligned tables.
+
+    Each level is a table (aligned, scannable); every branch expands into its
+    children via ``<details>``, so the whole hierarchy is browsable down to the
+    operator level. It's all collapsed by default, and the summary lines carry
+    each branch's status so a reader can spot and open the failing paths without
+    expanding the green ones.
+    """
+    tree = analysis.get("by_feature", {})
+    if not tree.get("children"):
+        return []
+
+    lines = ["", "<details>", "<summary><b>Feature breakdown</b></summary>", ""]
+    lines.extend(_feature_nodes(tree))
+    lines.append("</details>")
+    return lines
+
+
 def render(analysis: Dict[str, Any]) -> str:
     """Render the full markdown report body."""
     lines = [_verdict_heading(analysis), ""]
     lines.extend(_breakdown_lines(analysis.get("reconciliation", {})))
     lines.extend(_needs_attention_lines(analysis))
+    lines.extend(_known_gaps_lines(analysis))
+    lines.extend(_skipped_lines(analysis))
+    lines.extend(_feature_breakdown_lines(analysis))
     return "\n".join(lines) + "\n"

--- a/documentdb_tests/compatibility/result_analyzer/render_markdown.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_markdown.py
@@ -6,6 +6,8 @@ markdown (headings, tables, and - in later sections - collapsible details).
 Presentation only; no selection logic lives here.
 """
 
+import html
+import re
 from typing import Any, Dict, List
 
 from .report_content import (
@@ -18,6 +20,23 @@ from .report_content import (
     pass_rate,
     skipped_tests,
 )
+
+
+def _table_cell(text: str) -> str:
+    """Escape a value for a markdown table cell: a raw | would split the row."""
+    return text.replace("|", "\\|")
+
+
+def _fenced_block(text: str) -> List[str]:
+    """
+    Wrap text in a code fence the text cannot terminate early.
+
+    A traceback can contain ``` (repr'd test data), so size the fence past the
+    longest backtick run inside.
+    """
+    longest_run = max((len(m) for m in re.findall(r"`+", text)), default=0)
+    fence = "`" * max(3, longest_run + 1)
+    return [fence, text, fence]
 
 
 def _verdict_heading(analysis: Dict[str, Any]) -> str:
@@ -96,16 +115,14 @@ def _needs_attention_lines(analysis: Dict[str, Any]) -> List[str]:
 
 def _failure_details(test: Dict[str, Any]) -> List[str]:
     """One collapsible entry: summary line + traceback in a code block."""
-    name = test.get("name", "")
+    name = html.escape(test.get("name", ""))
     outcome = test.get("outcome", "")
     traceback = test.get("error") or "(no traceback captured)"
     return [
         "<details>",
         f"<summary>{outcome}: <code>{name}</code></summary>",
         "",
-        "```",
-        traceback.rstrip(),
-        "```",
+        *_fenced_block(traceback.rstrip()),
         "</details>",
         "",
     ]
@@ -136,8 +153,8 @@ def _known_gaps_lines(analysis: Dict[str, Any]) -> List[str]:
     lines.append("| Test | Reason |")
     lines.append("|---|---|")
     for gap in gaps:
-        reason = gap["reason"] or "-"
-        lines.append(f"| `{gap['name']}` | {reason} |")
+        reason = _table_cell(gap["reason"]) or "-"
+        lines.append(f"| `{_table_cell(gap['name'])}` | {reason} |")
     lines.append("")
     lines.append("</details>")
     return lines
@@ -165,8 +182,8 @@ def _skipped_lines(analysis: Dict[str, Any]) -> List[str]:
     lines.append("| Test | Reason |")
     lines.append("|---|---|")
     for test in skipped:
-        reason = test["reason"] or "-"
-        lines.append(f"| `{test['name']}` | {reason} |")
+        reason = _table_cell(test["reason"]) or "-"
+        lines.append(f"| `{_table_cell(test['name'])}` | {reason} |")
     lines.append("")
     lines.append("</details>")
     return lines

--- a/documentdb_tests/compatibility/result_analyzer/render_markdown.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_markdown.py
@@ -115,15 +115,24 @@ def _known_gaps_lines(analysis: Dict[str, Any]) -> List[str]:
     """
     Documented incompatibilities (xfailed), collapsed by default.
 
-    These are expected gaps, not regressions, so they're tucked behind a
+    These are expected gaps, not regressions, so the detail sits behind a
     ``<details>`` - out of the way for the common reader, but available as a
-    plain-English catalogue of what doesn't work and why.
+    plain-English catalogue of what doesn't work and why. The section carries its
+    own heading so it reads as a peer of needs-attention rather than blending
+    into that section's per-failure-type dropdowns.
     """
     gaps = known_gaps(analysis)
     if not gaps:
         return []
 
-    lines = ["", "<details>", f"<summary><b>Known gaps ({len(gaps)})</b></summary>", ""]
+    lines = [
+        "",
+        f"### Known gaps ({len(gaps)})",
+        "",
+        "<details>",
+        "<summary>Show all</summary>",
+        "",
+    ]
     lines.append("| Test | Reason |")
     lines.append("|---|---|")
     for gap in gaps:
@@ -139,13 +148,20 @@ def _skipped_lines(analysis: Dict[str, Any]) -> List[str]:
     Skipped tests with reasons, collapsed by default.
 
     Explains why tests didn't run (e.g. not applicable to this target), mirroring
-    known gaps — out of the way behind a ``<details>`` but answerable.
+    known gaps: its own heading, with the detail behind a ``<details>``.
     """
     skipped = skipped_tests(analysis)
     if not skipped:
         return []
 
-    lines = ["", "<details>", f"<summary><b>Skipped ({len(skipped)})</b></summary>", ""]
+    lines = [
+        "",
+        f"### Skipped ({len(skipped)})",
+        "",
+        "<details>",
+        "<summary>Show all</summary>",
+        "",
+    ]
     lines.append("| Test | Reason |")
     lines.append("|---|---|")
     for test in skipped:
@@ -294,7 +310,14 @@ def _feature_breakdown_lines(analysis: Dict[str, Any]) -> List[str]:
     if not tree.get("children"):
         return []
 
-    lines = ["", "<details>", "<summary><b>Feature breakdown</b></summary>", ""]
+    lines = [
+        "",
+        "### Feature breakdown",
+        "",
+        "<details>",
+        "<summary>Show all</summary>",
+        "",
+    ]
     lines.extend(_feature_nodes(tree))
     lines.append("</details>")
     return lines

--- a/documentdb_tests/compatibility/result_analyzer/render_text.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_text.py
@@ -9,7 +9,9 @@ aligned text. Presentation only; the selection logic lives in ``report_content``
 from typing import Any, Dict, List
 
 from .report_content import (
+    NEEDS_ATTENTION_CAP,
     VERDICT_PASS,
+    cap_items,
     determine_verdict,
     group_needs_attention,
     pass_rate,
@@ -45,7 +47,7 @@ def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
 
 
 def _needs_attention_lines(analysis: Dict[str, Any]) -> List[str]:
-    """Failures and errors, grouped by failure type, as a plain list."""
+    """Failures and errors, grouped by failure type, as a plain list (capped)."""
     grouped = group_needs_attention(analysis)
     if not grouped:
         return []
@@ -54,8 +56,11 @@ def _needs_attention_lines(analysis: Dict[str, Any]) -> List[str]:
     for failure_type in sorted(grouped):
         tests = grouped[failure_type]
         lines.append(f"  {failure_type} ({len(tests)}):")
-        for test in tests:
+        shown, omitted = cap_items(tests)
+        for test in shown:
             lines.append(f"    {test['outcome']}: {test['name']}")
+        if omitted:
+            lines.append(f"    ... and {omitted} more (cap {NEEDS_ATTENTION_CAP})")
     return lines
 
 

--- a/documentdb_tests/compatibility/result_analyzer/render_text.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_text.py
@@ -1,0 +1,119 @@
+"""
+Plain-text rendering for local/terminal use.
+
+Consumes the format-agnostic report content and draws it as aligned monospace
+text, which reads better in a terminal than raw markdown. Presentation only.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from .report_content import group_failures_by_type, tag_rows, tests_with_outcome
+
+
+def _xpass_warning_lines(xpassed_tests: List[Dict[str, Any]], indent: str) -> List[str]:
+    """Shared strict-xpass alarm text (a raw XPASS means pytest.ini wasn't applied)."""
+    lines = [
+        f"⚠ ERROR: {len(xpassed_tests)} test(s) unexpectedly passed (XPASS).",
+        "  With xfail_strict=true, these should appear as failures instead.",
+        "  If you see this, the test run may not have used pytest.ini.",
+    ]
+    return lines + [f"{indent}{t['name']}" for t in xpassed_tests]
+
+
+def render(analysis: Dict[str, Any]) -> str:
+    """Render the full plain-text report body."""
+    lines: List[str] = []
+
+    lines.append("=" * 80)
+    lines.append("DocumentDB Functional Test Results")
+    lines.append("=" * 80)
+    lines.append(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}")
+    lines.append("")
+
+    summary = analysis["summary"]
+    lines.append("SUMMARY")
+    lines.append("-" * 80)
+    lines.append(f"Total Tests:  {summary['total']}")
+    lines.append(f"Passed:       {summary['passed']} ({summary['pass_rate']}%)")
+    lines.append(f"Failed:       {summary['failed']}")
+    lines.append(f"Skipped:      {summary['skipped']}")
+    lines.append(f"XFailed:      {summary['xfailed']}")
+    lines.append(f"XPassed:      {summary['xpassed']}")
+    lines.append("")
+
+    lines.append("RESULTS BY TAG")
+    lines.append("-" * 80)
+    rows = tag_rows(analysis)
+    if rows:
+        for t in rows:
+            lines.append(f"\n{t['tag']}:")
+            lines.append(f"  Total:   {t['total']}")
+            lines.append(f"  Passed:  {t['passed']} ({t['pass_rate']}%)")
+            lines.append(f"  Failed:  {t['failed']}")
+            lines.append(f"  Skipped: {t['skipped']}")
+    else:
+        lines.append("No tags found in test results.")
+    lines.append("")
+
+    grouped = group_failures_by_type(analysis)
+    if grouped:
+        lines.append("FAILED TESTS")
+        lines.append("-" * 80)
+        for ft in sorted(grouped):
+            lines.append(f"\n  {ft} ({len(grouped[ft])}):")
+            for test in grouped[ft]:
+                lines.append(f"\n    {test['name']}")
+                lines.append(f"      Tags: {', '.join(test['tags'])}")
+                lines.append(f"      Duration: {test['duration']:.2f}s")
+                if "error" in test:
+                    lines.append(f"      Error: {test['error'][:200]}...")
+
+    skipped_tests = tests_with_outcome(analysis, "SKIPPED")
+    if skipped_tests:
+        lines.append("")
+        lines.append("SKIPPED TESTS")
+        lines.append("-" * 80)
+        for test in skipped_tests:
+            lines.append(f"  {test['name']}")
+
+    xpassed_tests = tests_with_outcome(analysis, "XPASS")
+    if xpassed_tests:
+        lines.append("")
+        lines.extend(_xpass_warning_lines(xpassed_tests, "    "))
+
+    lines.append("")
+    lines.append("=" * 80)
+
+    return "\n".join(lines) + "\n"
+
+
+def print_summary(analysis: Dict[str, Any]):
+    """Print a brief summary to the console."""
+    summary = analysis["summary"]
+    print("\n" + "=" * 60)
+    print("Test Results Summary")
+    print("=" * 60)
+    print(f"Total:   {summary['total']}")
+    print(f"Passed:  {summary['passed']} ({summary['pass_rate']}%)")
+    print(f"Failed:  {summary['failed']}")
+    print(f"Skipped: {summary['skipped']}")
+    print(f"XFailed: {summary['xfailed']}")
+    print(f"XPassed: {summary['xpassed']}")
+    print("=" * 60)
+
+    grouped = group_failures_by_type(analysis)
+    if grouped:
+        total = sum(len(v) for v in grouped.values())
+        print(f"\nFailed Tests ({total}):")
+        print("-" * 60)
+        for ft in sorted(grouped):
+            print(f"  {ft}: {len(grouped[ft])}")
+
+    if summary["xpassed"] > 0:
+        xpassed_tests = tests_with_outcome(analysis, "XPASS")
+        print()
+        for line in _xpass_warning_lines(xpassed_tests, "    "):
+            print(line)
+
+    print("=" * 60 + "\n")

--- a/documentdb_tests/compatibility/result_analyzer/render_text.py
+++ b/documentdb_tests/compatibility/result_analyzer/render_text.py
@@ -1,119 +1,72 @@
 """
 Plain-text rendering for local/terminal use.
 
-Consumes the format-agnostic report content and draws it as aligned monospace
-text, which reads better in a terminal than raw markdown. Presentation only.
+Consumes the format-agnostic report content and shows the same information as the
+markdown report - verdict, run breakdown, and what needs attention - as concise
+aligned text. Presentation only; the selection logic lives in ``report_content``.
 """
 
-from datetime import datetime, timezone
 from typing import Any, Dict, List
 
-from .report_content import group_failures_by_type, tag_rows, tests_with_outcome
+from .report_content import (
+    VERDICT_PASS,
+    determine_verdict,
+    group_needs_attention,
+    pass_rate,
+)
 
 
-def _xpass_warning_lines(xpassed_tests: List[Dict[str, Any]], indent: str) -> List[str]:
-    """Shared strict-xpass alarm text (a raw XPASS means pytest.ini wasn't applied)."""
-    lines = [
-        f"⚠ ERROR: {len(xpassed_tests)} test(s) unexpectedly passed (XPASS).",
-        "  With xfail_strict=true, these should appear as failures instead.",
-        "  If you see this, the test run may not have used pytest.ini.",
+def _verdict_line(analysis: Dict[str, Any]) -> str:
+    verdict, reason = determine_verdict(analysis.get("reconciliation", {}))
+    mark = "PASS" if verdict == VERDICT_PASS else "FAIL"
+    return f"{mark}{f' - {reason}' if reason else ''}"
+
+
+def _breakdown_lines(reconciliation: Dict[str, Any]) -> List[str]:
+    """The run breakdown: collected decomposed into deselected vs each outcome."""
+    r = reconciliation
+    rows = [
+        ("Collected", r.get("collected", 0)),
+        ("  Unsupported", r.get("deselected", 0)),
+        ("  Executed", r.get("total", 0)),
+        ("    Passed", r.get("passed", 0)),
+        ("    Failed", r.get("failed", 0)),
+        ("    Errored", r.get("error", 0)),
+        ("    Skipped", r.get("skipped", 0)),
+        ("    Known gaps", r.get("xfailed", 0)),
     ]
-    return lines + [f"{indent}{t['name']}" for t in xpassed_tests]
+    if r.get("xpassed", 0):
+        rows.append(("    Unexpected passes", r.get("xpassed", 0)))
+    width = max(len(label) for label, _ in rows)
+    lines = [f"{label.ljust(width)}  {count}" for label, count in rows]
+    lines.append("")
+    lines.append(f"Pass rate: {pass_rate(r)}")
+    return lines
+
+
+def _needs_attention_lines(analysis: Dict[str, Any]) -> List[str]:
+    """Failures and errors, grouped by failure type, as a plain list."""
+    grouped = group_needs_attention(analysis)
+    if not grouped:
+        return []
+    total = sum(len(v) for v in grouped.values())
+    lines = ["", f"Needs attention ({total}):"]
+    for failure_type in sorted(grouped):
+        tests = grouped[failure_type]
+        lines.append(f"  {failure_type} ({len(tests)}):")
+        for test in tests:
+            lines.append(f"    {test['outcome']}: {test['name']}")
+    return lines
 
 
 def render(analysis: Dict[str, Any]) -> str:
-    """Render the full plain-text report body."""
-    lines: List[str] = []
-
-    lines.append("=" * 80)
-    lines.append("DocumentDB Functional Test Results")
-    lines.append("=" * 80)
-    lines.append(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}")
-    lines.append("")
-
-    summary = analysis["summary"]
-    lines.append("SUMMARY")
-    lines.append("-" * 80)
-    lines.append(f"Total Tests:  {summary['total']}")
-    lines.append(f"Passed:       {summary['passed']} ({summary['pass_rate']}%)")
-    lines.append(f"Failed:       {summary['failed']}")
-    lines.append(f"Skipped:      {summary['skipped']}")
-    lines.append(f"XFailed:      {summary['xfailed']}")
-    lines.append(f"XPassed:      {summary['xpassed']}")
-    lines.append("")
-
-    lines.append("RESULTS BY TAG")
-    lines.append("-" * 80)
-    rows = tag_rows(analysis)
-    if rows:
-        for t in rows:
-            lines.append(f"\n{t['tag']}:")
-            lines.append(f"  Total:   {t['total']}")
-            lines.append(f"  Passed:  {t['passed']} ({t['pass_rate']}%)")
-            lines.append(f"  Failed:  {t['failed']}")
-            lines.append(f"  Skipped: {t['skipped']}")
-    else:
-        lines.append("No tags found in test results.")
-    lines.append("")
-
-    grouped = group_failures_by_type(analysis)
-    if grouped:
-        lines.append("FAILED TESTS")
-        lines.append("-" * 80)
-        for ft in sorted(grouped):
-            lines.append(f"\n  {ft} ({len(grouped[ft])}):")
-            for test in grouped[ft]:
-                lines.append(f"\n    {test['name']}")
-                lines.append(f"      Tags: {', '.join(test['tags'])}")
-                lines.append(f"      Duration: {test['duration']:.2f}s")
-                if "error" in test:
-                    lines.append(f"      Error: {test['error'][:200]}...")
-
-    skipped_tests = tests_with_outcome(analysis, "SKIPPED")
-    if skipped_tests:
-        lines.append("")
-        lines.append("SKIPPED TESTS")
-        lines.append("-" * 80)
-        for test in skipped_tests:
-            lines.append(f"  {test['name']}")
-
-    xpassed_tests = tests_with_outcome(analysis, "XPASS")
-    if xpassed_tests:
-        lines.append("")
-        lines.extend(_xpass_warning_lines(xpassed_tests, "    "))
-
-    lines.append("")
-    lines.append("=" * 80)
-
+    """Render the plain-text report body."""
+    lines = [f"Verdict: {_verdict_line(analysis)}", ""]
+    lines.extend(_breakdown_lines(analysis.get("reconciliation", {})))
+    lines.extend(_needs_attention_lines(analysis))
     return "\n".join(lines) + "\n"
 
 
 def print_summary(analysis: Dict[str, Any]):
-    """Print a brief summary to the console."""
-    summary = analysis["summary"]
-    print("\n" + "=" * 60)
-    print("Test Results Summary")
-    print("=" * 60)
-    print(f"Total:   {summary['total']}")
-    print(f"Passed:  {summary['passed']} ({summary['pass_rate']}%)")
-    print(f"Failed:  {summary['failed']}")
-    print(f"Skipped: {summary['skipped']}")
-    print(f"XFailed: {summary['xfailed']}")
-    print(f"XPassed: {summary['xpassed']}")
-    print("=" * 60)
-
-    grouped = group_failures_by_type(analysis)
-    if grouped:
-        total = sum(len(v) for v in grouped.values())
-        print(f"\nFailed Tests ({total}):")
-        print("-" * 60)
-        for ft in sorted(grouped):
-            print(f"  {ft}: {len(grouped[ft])}")
-
-    if summary["xpassed"] > 0:
-        xpassed_tests = tests_with_outcome(analysis, "XPASS")
-        print()
-        for line in _xpass_warning_lines(xpassed_tests, "    "):
-            print(line)
-
-    print("=" * 60 + "\n")
+    """Print the plain-text report to the console."""
+    print(render(analysis))

--- a/documentdb_tests/compatibility/result_analyzer/report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_content.py
@@ -1,0 +1,43 @@
+"""
+Format-agnostic report content.
+
+Decides *what* a report should say — which tests belong in each section —
+independent of how it is drawn. Renderers (text, markdown) consume these results
+and are responsible only for presentation, so the selection logic lives in
+exactly one place.
+"""
+
+from typing import Any, Dict, List
+
+
+def group_failures_by_type(analysis: Dict[str, Any]) -> Dict[str, list]:
+    """Group failed tests by their failure_type (RESULT_MISMATCH, INFRA_ERROR, ...)."""
+    failed_tests = [t for t in analysis["tests"] if t["outcome"] == "FAIL"]
+    grouped: Dict[str, list] = {}
+    for test in failed_tests:
+        ft = test.get("failure_type", "UNKNOWN")
+        grouped.setdefault(ft, []).append(test)
+    return grouped
+
+
+def tag_rows(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return per-tag rows sorted worst-pass-rate-first, ready for tabulation."""
+    rows = []
+    by_tag = analysis.get("by_tag", {})
+    for tag, stats in sorted(by_tag.items(), key=lambda x: x[1]["pass_rate"]):
+        rows.append(
+            {
+                "tag": tag,
+                "passed": stats["passed"],
+                "total": stats["total"],
+                "failed": stats["failed"],
+                "skipped": stats["skipped"],
+                "pass_rate": stats["pass_rate"],
+            }
+        )
+    return rows
+
+
+def tests_with_outcome(analysis: Dict[str, Any], outcome: str) -> List[Dict[str, Any]]:
+    """Return the tests whose categorized outcome matches (e.g. SKIPPED, XPASS)."""
+    return [t for t in analysis["tests"] if t["outcome"] == outcome]

--- a/documentdb_tests/compatibility/result_analyzer/report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_content.py
@@ -1,13 +1,52 @@
 """
 Format-agnostic report content.
 
-Decides *what* a report should say — which tests belong in each section —
-independent of how it is drawn. Renderers (text, markdown) consume these results
-and are responsible only for presentation, so the selection logic lives in
-exactly one place.
+Decides *what* a report should say — the verdict, and which tests belong in each
+section — independent of how it is drawn. Renderers (text, markdown) consume
+these results and are responsible only for presentation, so the selection logic
+lives in exactly one place.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
+
+VERDICT_PASS = "PASS"
+VERDICT_FAIL = "FAIL"
+
+
+def determine_verdict(reconciliation: Dict[str, Any]) -> Tuple[str, str]:
+    """
+    Decide the binary run verdict and a one-line reason.
+
+    Anything that isn't a clean, meaningful, all-passing run is a FAIL; the
+    breakdown section carries the detail. The checks run in priority order so
+    the most serious explanation wins:
+
+    1. A raw ``xpassed`` means ``xfail_strict`` wasn't applied, so the run's
+       results can't be trusted — flag it as invalid.
+    2. No test reached a verdict (all deselected/skipped) — a run with nothing to
+       show for it is treated as a failure, not a silent pass.
+    3. Any failure or error.
+    Otherwise PASS.
+
+    Args:
+        reconciliation: The reconciliation counts from the analysis.
+
+    Returns:
+        A ``(verdict, reason)`` pair; ``reason`` is empty on PASS.
+    """
+    executed = (
+        reconciliation.get("passed", 0)
+        + reconciliation.get("failed", 0)
+        + reconciliation.get("error", 0)
+    )
+
+    if reconciliation.get("xpassed", 0) > 0:
+        return VERDICT_FAIL, "results may be invalid — strict xfail not applied"
+    if executed == 0:
+        return VERDICT_FAIL, "no tests ran"
+    if reconciliation.get("failed", 0) or reconciliation.get("error", 0):
+        return VERDICT_FAIL, "tests failed"
+    return VERDICT_PASS, ""
 
 
 def group_failures_by_type(analysis: Dict[str, Any]) -> Dict[str, list]:

--- a/documentdb_tests/compatibility/result_analyzer/report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_content.py
@@ -59,6 +59,44 @@ def group_failures_by_type(analysis: Dict[str, Any]) -> Dict[str, list]:
     return grouped
 
 
+# Above this many needs-attention items, the report lists a capped sample rather
+# than every traceback. A mass failure would otherwise bury the summary and blow
+# past the step-summary size limit.
+NEEDS_ATTENTION_CAP = 25
+
+
+def needs_attention(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Return the tests a human must act on: failures and errors.
+
+    A FAIL reached a verdict and was wrong; an ERROR never reached one (a crash,
+    usually in a fixture). Both need attention, so they're surfaced together —
+    each still tagged with its outcome so a renderer can distinguish them.
+    """
+    return [t for t in analysis["tests"] if t["outcome"] in ("FAIL", "ERROR")]
+
+
+def group_needs_attention(analysis: Dict[str, Any]) -> Dict[str, list]:
+    """Group needs-attention tests by failure_type, for sectioned display."""
+    grouped: Dict[str, list] = {}
+    for test in needs_attention(analysis):
+        ft = test.get("failure_type", "UNKNOWN")
+        grouped.setdefault(ft, []).append(test)
+    return grouped
+
+
+def cap_items(items: List[Any], cap: int = NEEDS_ATTENTION_CAP) -> Tuple[List[Any], int]:
+    """
+    Trim a list to at most ``cap`` items.
+
+    Returns the kept items and the number omitted, so a renderer can show
+    "N more not shown" instead of an overwhelming wall of tracebacks.
+    """
+    if len(items) <= cap:
+        return items, 0
+    return items[:cap], len(items) - cap
+
+
 def tag_rows(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Return per-tag rows sorted worst-pass-rate-first, ready for tabulation."""
     rows = []

--- a/documentdb_tests/compatibility/result_analyzer/report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_content.py
@@ -50,16 +50,6 @@ def determine_verdict(reconciliation: Dict[str, Any]) -> Tuple[str, str]:
     return VERDICT_PASS, ""
 
 
-def group_failures_by_type(analysis: Dict[str, Any]) -> Dict[str, list]:
-    """Group failed tests by their failure_type (RESULT_MISMATCH, INFRA_ERROR, ...)."""
-    failed_tests = [t for t in analysis["tests"] if t["outcome"] == "FAIL"]
-    grouped: Dict[str, list] = {}
-    for test in failed_tests:
-        ft = test.get("failure_type", "UNKNOWN")
-        grouped.setdefault(ft, []).append(test)
-    return grouped
-
-
 # Above this many needs-attention items, the report lists a capped sample rather
 # than every traceback. A mass failure would otherwise bury the summary and blow
 # past the step-summary size limit.
@@ -147,26 +137,3 @@ def pass_rate(counts: Dict[str, Any]) -> str:
         return "100%"
     # Truncate to 1dp so a near-perfect-but-not-clean node never shows 100%.
     return f"{math.floor(passed / counted * 1000) / 10}%"
-
-
-def tag_rows(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Return per-tag rows sorted worst-pass-rate-first, ready for tabulation."""
-    rows = []
-    by_tag = analysis.get("by_tag", {})
-    for tag, stats in sorted(by_tag.items(), key=lambda x: x[1]["pass_rate"]):
-        rows.append(
-            {
-                "tag": tag,
-                "passed": stats["passed"],
-                "total": stats["total"],
-                "failed": stats["failed"],
-                "skipped": stats["skipped"],
-                "pass_rate": stats["pass_rate"],
-            }
-        )
-    return rows
-
-
-def tests_with_outcome(analysis: Dict[str, Any], outcome: str) -> List[Dict[str, Any]]:
-    """Return the tests whose categorized outcome matches (e.g. SKIPPED, XPASS)."""
-    return [t for t in analysis["tests"] if t["outcome"] == outcome]

--- a/documentdb_tests/compatibility/result_analyzer/report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_content.py
@@ -7,6 +7,7 @@ these results and are responsible only for presentation, so the selection logic
 lives in exactly one place.
 """
 
+import math
 from typing import Any, Dict, List, Tuple
 
 VERDICT_PASS = "PASS"
@@ -95,6 +96,57 @@ def cap_items(items: List[Any], cap: int = NEEDS_ATTENTION_CAP) -> Tuple[List[An
     if len(items) <= cap:
         return items, 0
     return items[:cap], len(items) - cap
+
+
+def known_gaps(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Return the xfailed tests — documented incompatibilities — with their reasons.
+
+    These are expected, not regressions, so they're reported separately from
+    needs-attention. Each entry carries the test name and its recorded reason.
+    """
+    gaps = []
+    for test in analysis["tests"]:
+        if test["outcome"] == "XFAIL":
+            gaps.append({"name": test["name"], "reason": test.get("xfail_reason", "")})
+    return gaps
+
+
+def skipped_tests(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Return the skipped tests with their reasons.
+
+    A skip is a deliberate "not run here" (e.g. not applicable to this target),
+    so — like known gaps — it's worth explaining rather than showing as a bare
+    count. Each entry carries the test name and its recorded reason.
+    """
+    skipped = []
+    for test in analysis["tests"]:
+        if test["outcome"] == "SKIPPED":
+            skipped.append({"name": test["name"], "reason": test.get("skip_reason", "")})
+    return skipped
+
+
+def pass_rate(counts: Dict[str, Any]) -> str:
+    """
+    Format a node's pass rate over verdict-bearing outcomes.
+
+    Only a genuinely clean node (no failures or errors) may read 100%. When
+    something failed, the rate is truncated rather than rounded, so a handful of
+    failures diluted by tens of thousands of passes can't round up to a
+    misleading 100%.
+
+    Returns a percent string, or "—" when nothing ran.
+    """
+    passed = counts.get("passed", 0)
+    bad = counts.get("failed", 0) + counts.get("error", 0)
+    counted = passed + bad
+    if counted == 0:
+        return "—"
+    if bad == 0:
+        return "100%"
+    # Truncate to 1dp so a near-perfect-but-not-clean node never shows 100%.
+    return f"{math.floor(passed / counted * 1000) / 10}%"
 
 
 def tag_rows(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/documentdb_tests/compatibility/result_analyzer/report_generator.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_generator.py
@@ -9,7 +9,7 @@ re-exported here for backward compatibility with existing imports.
 
 from typing import Any, Callable, Dict
 
-from . import render_json, render_text
+from . import render_json, render_markdown, render_text
 from .render_text import print_summary
 
 __all__ = ["generate_report", "print_summary"]
@@ -19,6 +19,7 @@ __all__ = ["generate_report", "print_summary"]
 _RENDERERS: Dict[str, Callable[[Dict[str, Any]], str]] = {
     "json": render_json.render,
     "text": render_text.render,
+    "markdown": render_markdown.render,
 }
 
 

--- a/documentdb_tests/compatibility/result_analyzer/report_generator.py
+++ b/documentdb_tests/compatibility/result_analyzer/report_generator.py
@@ -1,13 +1,25 @@
 """
-Report generator for creating human-readable reports from analysis results.
+Report generation entry point.
 
-This module provides functions to generate various report formats from
-analyzed test results.
+Thin dispatch layer: picks a renderer by format name and writes its output.
+Selection logic lives in ``report_content``; drawing lives in the ``render_*``
+modules, each exposing ``render(analysis) -> str``. ``print_summary`` is
+re-exported here for backward compatibility with existing imports.
 """
 
-import json
-from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Callable, Dict
+
+from . import render_json, render_text
+from .render_text import print_summary
+
+__all__ = ["generate_report", "print_summary"]
+
+# Format name -> renderer. Each renderer takes the analysis and returns the
+# report body as a string.
+_RENDERERS: Dict[str, Callable[[Dict[str, Any]], str]] = {
+    "json": render_json.render,
+    "text": render_text.render,
+}
 
 
 def generate_report(analysis: Dict[str, Any], output_path: str, format: str = "json"):
@@ -17,183 +29,11 @@ def generate_report(analysis: Dict[str, Any], output_path: str, format: str = "j
     Args:
         analysis: Analysis results from analyze_results()
         output_path: Path to write the report
-        format: Report format ("json" or "text")
+        format: Report format (one of ``_RENDERERS``)
     """
-    if format == "json":
-        generate_json_report(analysis, output_path)
-    elif format == "text":
-        generate_text_report(analysis, output_path)
-    else:
+    try:
+        renderer = _RENDERERS[format]
+    except KeyError:
         raise ValueError(f"Unsupported report format: {format}")
-
-
-def generate_json_report(analysis: Dict[str, Any], output_path: str):
-    """
-    Generate a JSON report.
-
-    Args:
-        analysis: Analysis results from analyze_results()
-        output_path: Path to write the JSON report
-    """
-    report = {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "summary": analysis["summary"],
-        "by_tag": analysis["by_tag"],
-        "tests": analysis["tests"],
-    }
-
     with open(output_path, "w") as f:
-        json.dump(report, f, indent=2)
-
-
-def _format_by_tag(analysis: Dict[str, Any]) -> list:
-    """Format by-tag results as lines. Shared by both report functions."""
-    lines = []
-    by_tag = analysis.get("by_tag", {})
-    if by_tag:
-        sorted_tags = sorted(by_tag.items(), key=lambda x: x[1]["pass_rate"])
-        for tag, stats in sorted_tags:
-            lines.append(
-                {
-                    "tag": tag,
-                    "passed": stats["passed"],
-                    "total": stats["total"],
-                    "failed": stats["failed"],
-                    "skipped": stats["skipped"],
-                    "pass_rate": stats["pass_rate"],
-                }
-            )
-    return lines
-
-
-def _categorize_failures(analysis: Dict[str, Any]) -> Dict[str, list]:
-    """Group failed tests by failure_type. Shared by both report functions."""
-    failed_tests = [t for t in analysis["tests"] if t["outcome"] == "FAIL"]
-    grouped: Dict[str, list] = {}
-    for test in failed_tests:
-        ft = test.get("failure_type", "UNKNOWN")
-        grouped.setdefault(ft, []).append(test)
-    return grouped
-
-
-def generate_text_report(analysis: Dict[str, Any], output_path: str):
-    """
-    Generate a detailed human-readable text report to file.
-
-    Args:
-        analysis: Analysis results from analyze_results()
-        output_path: Path to write the text report
-    """
-    lines = []
-
-    # Header
-    lines.append("=" * 80)
-    lines.append("DocumentDB Functional Test Results")
-    lines.append("=" * 80)
-    lines.append(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}")
-    lines.append("")
-
-    # Summary
-    summary = analysis["summary"]
-    lines.append("SUMMARY")
-    lines.append("-" * 80)
-    lines.append(f"Total Tests:  {summary['total']}")
-    lines.append(f"Passed:       {summary['passed']} ({summary['pass_rate']}%)")
-    lines.append(f"Failed:       {summary['failed']}")
-    lines.append(f"Skipped:      {summary['skipped']}")
-    lines.append(f"XFailed:      {summary['xfailed']}")
-    lines.append(f"XPassed:      {summary['xpassed']}")
-    lines.append("")
-
-    # Results by tag
-    lines.append("RESULTS BY TAG")
-    lines.append("-" * 80)
-    tag_data = _format_by_tag(analysis)
-    if tag_data:
-        for t in tag_data:
-            lines.append(f"\n{t['tag']}:")
-            lines.append(f"  Total:   {t['total']}")
-            lines.append(f"  Passed:  {t['passed']} ({t['pass_rate']}%)")
-            lines.append(f"  Failed:  {t['failed']}")
-            lines.append(f"  Skipped: {t['skipped']}")
-    else:
-        lines.append("No tags found in test results.")
-    lines.append("")
-
-    # Failed tests details
-    grouped = _categorize_failures(analysis)
-    if grouped:
-        lines.append("FAILED TESTS")
-        lines.append("-" * 80)
-        for ft in sorted(grouped):
-            lines.append(f"\n  {ft} ({len(grouped[ft])}):")
-            for test in grouped[ft]:
-                lines.append(f"\n    {test['name']}")
-                lines.append(f"      Tags: {', '.join(test['tags'])}")
-                lines.append(f"      Duration: {test['duration']:.2f}s")
-                if "error" in test:
-                    lines.append(f"      Error: {test['error'][:200]}...")
-
-    # Skipped tests
-    skipped_tests = [t for t in analysis["tests"] if t["outcome"] == "SKIPPED"]
-    if skipped_tests:
-        lines.append("")
-        lines.append("SKIPPED TESTS")
-        lines.append("-" * 80)
-        for test in skipped_tests:
-            lines.append(f"  {test['name']}")
-
-    # XPASS warning
-    xpassed_tests = [t for t in analysis["tests"] if t["outcome"] == "XPASS"]
-    if xpassed_tests:
-        lines.append("")
-        lines.append(f"⚠ ERROR: {len(xpassed_tests)} test(s) unexpectedly passed (XPASS).")
-        lines.append("  With xfail_strict=true, these should appear as failures instead.")
-        lines.append("  If you see this, the test run may not have used pytest.ini.")
-        for test in xpassed_tests:
-            lines.append(f"    {test['name']}")
-
-    lines.append("")
-    lines.append("=" * 80)
-
-    with open(output_path, "w") as f:
-        f.write("\n".join(lines) + "\n")
-
-
-def print_summary(analysis: Dict[str, Any]):
-    """
-    Print a brief summary to console.
-
-    Args:
-        analysis: Analysis results from analyze_results()
-    """
-    summary = analysis["summary"]
-    print("\n" + "=" * 60)
-    print("Test Results Summary")
-    print("=" * 60)
-    print(f"Total:   {summary['total']}")
-    print(f"Passed:  {summary['passed']} ({summary['pass_rate']}%)")
-    print(f"Failed:  {summary['failed']}")
-    print(f"Skipped: {summary['skipped']}")
-    print(f"XFailed: {summary['xfailed']}")
-    print(f"XPassed: {summary['xpassed']}")
-    print("=" * 60)
-
-    # Failed test counts by type
-    grouped = _categorize_failures(analysis)
-    if grouped:
-        total = sum(len(v) for v in grouped.values())
-        print(f"\nFailed Tests ({total}):")
-        print("-" * 60)
-        for ft in sorted(grouped):
-            print(f"  {ft}: {len(grouped[ft])}")
-
-    if summary["xpassed"] > 0:
-        xpassed_tests = [t for t in analysis["tests"] if t["outcome"] == "XPASS"]
-        print(f"\n⚠ ERROR: {summary['xpassed']} test(s) unexpectedly passed (XPASS).")
-        print("  With xfail_strict=true, these should appear as failures instead.")
-        print("  If you see this, the test run may not have used pytest.ini.")
-        for t in xpassed_tests:
-            print(f"    {t['name']}")
-
-    print("=" * 60 + "\n")
+        f.write(renderer(analysis))

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -14,6 +14,18 @@ def _make_test_result(crash_message: str) -> dict:
     return {"call": {"crash": {"message": crash_message}}}
 
 
+def _make_setup_error_result(crash_message: str, longrepr: str = "") -> dict:
+    """An errored test: failure lives in the setup phase, with no call phase."""
+    return {
+        "setup": {
+            "outcome": "failed",
+            "crash": {"message": crash_message},
+            "longrepr": longrepr,
+        },
+        "teardown": {"outcome": "passed"},
+    }
+
+
 # --- extract_failure_tag ---
 
 
@@ -49,6 +61,15 @@ class TestExtractFailureTag:
 
     def test_missing_call(self):
         assert extract_failure_tag({}) == ""
+
+    def test_reads_setup_phase_when_no_call(self):
+        # Errored tests have no call phase; the tag must come from setup.
+        result = _make_setup_error_result("[TEST_EXCEPTION] fixture blew up")
+        assert extract_failure_tag(result) == "TEST_EXCEPTION"
+
+    def test_reads_strict_xpass_from_failing_phase(self):
+        result = {"call": {"outcome": "failed", "longrepr": "[XPASS(strict)] stale marker"}}
+        assert extract_failure_tag(result) == "XPASS_STRICT"
 
 
 # --- extract_exception_type ---
@@ -107,3 +128,8 @@ class TestIsInfrastructureError:
 
     def test_missing_call(self):
         assert is_infrastructure_error({}) is False
+
+    def test_reads_setup_phase_when_no_call(self):
+        # An infra crash during setup must still be detected without a call phase.
+        result = _make_setup_error_result("pymongo.errors.ConnectionFailure: connection lost")
+        assert is_infrastructure_error(result) is True

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -3,7 +3,9 @@
 import pytest
 
 from documentdb_tests.compatibility.result_analyzer.analyzer import (
+    TestOutcome,
     build_reconciliation,
+    categorize_outcome,
     extract_exception_type,
     extract_failure_tag,
     is_infrastructure_error,
@@ -191,3 +193,32 @@ class TestBuildReconciliation:
     def test_missing_keys_default_to_zero(self):
         result = build_reconciliation({})
         assert result["collected"] == 0 and result["pass_rate"] == 0.0
+
+
+# categorize_outcome.
+
+
+@pytest.mark.unit
+class TestCategorizeOutcome:
+    def test_passed(self):
+        assert categorize_outcome({"outcome": "passed"}) == TestOutcome.PASS
+
+    def test_error_is_its_own_category(self):
+        # A setup/fixture crash reports outcome "error"; it must not be lumped
+        # into FAIL (it never reached a verdict).
+        assert categorize_outcome({"outcome": "error"}) == TestOutcome.ERROR
+
+    def test_skipped(self):
+        assert categorize_outcome({"outcome": "skipped"}) == TestOutcome.SKIPPED
+
+    def test_xfailed(self):
+        assert categorize_outcome({"outcome": "xfailed"}) == TestOutcome.XFAIL
+
+    def test_xpassed(self):
+        assert categorize_outcome({"outcome": "xpassed"}) == TestOutcome.XPASS
+
+    def test_failed(self):
+        assert categorize_outcome({"outcome": "failed"}) == TestOutcome.FAIL
+
+    def test_unknown_outcome_defaults_to_fail(self):
+        assert categorize_outcome({"outcome": ""}) == TestOutcome.FAIL

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -3,6 +3,7 @@
 import pytest
 
 from documentdb_tests.compatibility.result_analyzer.analyzer import (
+    build_reconciliation,
     extract_exception_type,
     extract_failure_tag,
     is_infrastructure_error,
@@ -133,3 +134,60 @@ class TestIsInfrastructureError:
         # An infra crash during setup must still be detected without a call phase.
         result = _make_setup_error_result("pymongo.errors.ConnectionFailure: connection lost")
         assert is_infrastructure_error(result) is True
+
+
+# build_reconciliation.
+
+
+@pytest.mark.unit
+class TestBuildReconciliation:
+    def test_pass_rate_excludes_skipped_and_xfailed(self):
+        # Denominator is passed + failed + error; skipped/xfailed don't move it.
+        summary = {
+            "collected": 20,
+            "total": 20,
+            "passed": 8,
+            "failed": 2,
+            "error": 0,
+            "skipped": 5,
+            "xfailed": 5,
+        }
+        result = build_reconciliation(summary)
+        # 8 / (8 + 2 + 0) = 80%, not 8/20
+        assert result["pass_rate"] == 80.0
+
+    def test_error_counts_against_pass_rate(self):
+        # A run with any error cannot read 100%.
+        summary = {"total": 10, "passed": 9, "failed": 0, "error": 1}
+        result = build_reconciliation(summary)
+        assert result["pass_rate"] == 90.0
+
+    def test_all_passed_is_100(self):
+        summary = {"total": 5, "passed": 5, "failed": 0, "error": 0}
+        assert build_reconciliation(summary)["pass_rate"] == 100.0
+
+    def test_no_verdicts_is_zero_not_division_error(self):
+        # Everything deselected/skipped: denominator is 0, must not raise.
+        summary = {"collected": 12, "deselected": 4, "total": 8, "skipped": 8}
+        result = build_reconciliation(summary)
+        assert result["pass_rate"] == 0.0
+
+    def test_counts_are_surfaced_from_native_summary(self):
+        summary = {
+            "collected": 30,
+            "deselected": 5,
+            "total": 25,
+            "passed": 20,
+            "failed": 3,
+            "error": 2,
+            "skipped": 0,
+            "xfailed": 0,
+        }
+        result = build_reconciliation(summary)
+        assert result["collected"] == 30
+        assert result["deselected"] == 5
+        assert result["error"] == 2
+
+    def test_missing_keys_default_to_zero(self):
+        result = build_reconciliation({})
+        assert result["collected"] == 0 and result["pass_rate"] == 0.0

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -106,6 +106,21 @@ class TestExtractSkipReason:
         }
         assert extract_skip_reason(result) == "Requires auditing to be enabled"
 
+    def test_reads_double_quoted_reason(self):
+        # repr double-quotes the reason when it contains an apostrophe.
+        longrepr = str(("/path/test_x.py", 17, "Skipped: doesn't apply here"))
+        result = {"setup": {"outcome": "skipped", "longrepr": longrepr}}
+        assert extract_skip_reason(result) == "doesn't apply here"
+
+    def test_reads_reason_behind_xdist_worker_banner(self):
+        # Under xdist the worker prepends a banner line before the tuple.
+        longrepr = (
+            "[gw1] linux -- Python 3.12.13 /opt/hostedtoolcache/bin/python\n"
+            "('/path/test_x.py', 17, 'Skipped: Requires auditing to be enabled')"
+        )
+        result = {"setup": {"outcome": "skipped", "longrepr": longrepr}}
+        assert extract_skip_reason(result) == "Requires auditing to be enabled"
+
     def test_reads_reason_from_call_longrepr_for_runtime_skip(self):
         # A pytest.skip() inside the test body skips in the call phase, not setup.
         result = {

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -340,6 +340,12 @@ class TestFeaturePath:
     def test_missing_root_returns_empty(self):
         assert feature_path("some/other/path/test_x.py::test_y") == []
 
+    def test_directory_ending_in_tests_is_not_the_root(self):
+        assert feature_path("documentdb_tests/framework/test_x.py::test_y") == []
+
+    def test_root_at_start_of_relative_nodeid(self):
+        assert feature_path("tests/core/test_x.py::test_y") == ["core", "test_x.py"]
+
 
 # group_by_feature.
 

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -8,6 +8,7 @@ from documentdb_tests.compatibility.result_analyzer.analyzer import (
     categorize_outcome,
     extract_exception_type,
     extract_failure_tag,
+    extract_skip_reason,
     feature_path,
     group_by_feature,
     is_infrastructure_error,
@@ -75,6 +76,30 @@ class TestExtractFailureTag:
     def test_reads_strict_xpass_from_failing_phase(self):
         result = {"call": {"outcome": "failed", "longrepr": "[XPASS(strict)] stale marker"}}
         assert extract_failure_tag(result) == "XPASS_STRICT"
+
+
+# extract_skip_reason.
+
+
+@pytest.mark.unit
+class TestExtractSkipReason:
+    def test_reads_reason_from_setup_longrepr(self):
+        result = {
+            "setup": {
+                "outcome": "skipped",
+                "longrepr": "('/path/test_x.py', 17, 'Skipped: Requires auditing to be enabled')",
+            }
+        }
+        assert extract_skip_reason(result) == "Requires auditing to be enabled"
+
+    def test_no_setup_is_empty(self):
+        assert extract_skip_reason({}) == ""
+
+    def test_non_string_longrepr_is_empty(self):
+        assert extract_skip_reason({"setup": {"longrepr": None}}) == ""
+
+    def test_longrepr_without_skip_marker_is_empty(self):
+        assert extract_skip_reason({"setup": {"longrepr": "some other text"}}) == ""
 
 
 # --- extract_exception_type ---
@@ -310,3 +335,25 @@ class TestGroupByFeature:
     def test_empty_input(self):
         tree = group_by_feature([])
         assert tree["children"] == {} and tree["counts"]["passed"] == 0
+
+    def test_deselected_tests_appear_with_reasons(self):
+        base = "documentdb_tests/compatibility/tests/"
+        deselected = {
+            base + "changeStreams/insert/test_x.py::t": {"replica_set": True},
+            base + "changeStreams/update/test_y.py::t": {"replica_set": True},
+        }
+        tree = group_by_feature([], deselected)
+        cs = tree["children"]["changeStreams"]
+        # Deselected tests are counted separately (not as passed) and their
+        # required capability is recorded for display.
+        assert cs["counts"]["deselected"] == 2
+        assert cs["counts"]["passed"] == 0
+        assert cs["requires"] == {"replica_set"}
+
+    def test_deselected_and_run_tests_coexist(self):
+        base = "documentdb_tests/compatibility/tests/"
+        tests = [{"name": base + "core/operator/test_a.py::t", "outcome": TestOutcome.PASS}]
+        deselected = {base + "changeStreams/insert/test_x.py::t": {"replica_set": True}}
+        tree = group_by_feature(tests, deselected)
+        assert tree["children"]["core"]["counts"]["passed"] == 1
+        assert tree["children"]["changeStreams"]["counts"]["deselected"] == 1

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -77,6 +77,20 @@ class TestExtractFailureTag:
         result = {"call": {"outcome": "failed", "longrepr": "[XPASS(strict)] stale marker"}}
         assert extract_failure_tag(result) == "XPASS_STRICT"
 
+    def test_reads_strict_xpass_behind_xdist_worker_banner(self):
+        # Under xdist the worker prepends a banner line, so the marker is not
+        # at the start of the longrepr. Taken verbatim from a CI report.
+        result = {
+            "call": {
+                "outcome": "failed",
+                "longrepr": (
+                    "[gw2] linux -- Python 3.12.13 /opt/hostedtoolcache/bin/python\n"
+                    "[XPASS(strict)] pretend the operator is broken"
+                ),
+            }
+        }
+        assert extract_failure_tag(result) == "XPASS_STRICT"
+
 
 # extract_skip_reason.
 

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -92,14 +92,28 @@ class TestExtractSkipReason:
         }
         assert extract_skip_reason(result) == "Requires auditing to be enabled"
 
+    def test_reads_reason_from_call_longrepr_for_runtime_skip(self):
+        # A pytest.skip() inside the test body skips in the call phase, not setup.
+        result = {
+            "setup": {"outcome": "passed"},
+            "call": {
+                "outcome": "skipped",
+                "longrepr": "('/path/test_x.py', 34, 'Skipped: Engine supports the feature')",
+            },
+        }
+        assert extract_skip_reason(result) == "Engine supports the feature"
+
     def test_no_setup_is_empty(self):
         assert extract_skip_reason({}) == ""
 
     def test_non_string_longrepr_is_empty(self):
-        assert extract_skip_reason({"setup": {"longrepr": None}}) == ""
+        assert extract_skip_reason({"setup": {"outcome": "skipped", "longrepr": None}}) == ""
 
     def test_longrepr_without_skip_marker_is_empty(self):
-        assert extract_skip_reason({"setup": {"longrepr": "some other text"}}) == ""
+        assert (
+            extract_skip_reason({"setup": {"outcome": "skipped", "longrepr": "some other text"}})
+            == ""
+        )
 
 
 # --- extract_exception_type ---

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -221,6 +221,14 @@ class TestBuildReconciliation:
         result = build_reconciliation({})
         assert result["collected"] == 0 and result["pass_rate"] == 0.0
 
+    def test_deselected_derived_from_collected_minus_total(self):
+        # pytest often omits a 'deselected' count; derive it so the breakdown
+        # always reconciles: collected == deselected + total.
+        summary = {"collected": 100, "total": 80, "passed": 80}
+        result = build_reconciliation(summary)
+        assert result["deselected"] == 20
+        assert result["collected"] == result["deselected"] + result["total"]
+
 
 # categorize_outcome.
 

--- a/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_analyzer.py
@@ -8,6 +8,8 @@ from documentdb_tests.compatibility.result_analyzer.analyzer import (
     categorize_outcome,
     extract_exception_type,
     extract_failure_tag,
+    feature_path,
+    group_by_feature,
     is_infrastructure_error,
 )
 
@@ -222,3 +224,89 @@ class TestCategorizeOutcome:
 
     def test_unknown_outcome_defaults_to_fail(self):
         assert categorize_outcome({"outcome": ""}) == TestOutcome.FAIL
+
+
+# feature_path.
+
+
+@pytest.mark.unit
+class TestFeaturePath:
+    def test_extracts_path_including_file(self):
+        nodeid = (
+            "documentdb_tests/compatibility/tests/core/operator/expressions/"
+            "arithmetic/add/test_add_numeric.py::test_add"
+        )
+        assert feature_path(nodeid) == [
+            "core",
+            "operator",
+            "expressions",
+            "arithmetic",
+            "add",
+            "test_add_numeric.py",
+        ]
+
+    def test_shallow_path(self):
+        nodeid = (
+            "documentdb_tests/compatibility/tests/changeStreams/create/"
+            "test_smoke_changeStream_create.py::test_it"
+        )
+        assert feature_path(nodeid) == [
+            "changeStreams",
+            "create",
+            "test_smoke_changeStream_create.py",
+        ]
+
+    def test_file_is_deepest_tier_selector_dropped(self):
+        nodeid = "documentdb_tests/compatibility/tests/core/test_x.py::test_y[param]"
+        # Directory + file are tiers; the ::test[param] selector is dropped.
+        assert feature_path(nodeid) == ["core", "test_x.py"]
+
+    def test_missing_root_returns_empty(self):
+        assert feature_path("some/other/path/test_x.py::test_y") == []
+
+
+# group_by_feature.
+
+
+@pytest.mark.unit
+class TestGroupByFeature:
+    def _tests(self):
+        base = "documentdb_tests/compatibility/tests/"
+        return [
+            {"name": base + "core/operator/string/test_a.py::t", "outcome": TestOutcome.PASS},
+            {"name": base + "core/operator/string/test_b.py::t", "outcome": TestOutcome.FAIL},
+            {"name": base + "core/operator/array/test_c.py::t", "outcome": TestOutcome.PASS},
+            {"name": base + "system/security/test_d.py::t", "outcome": TestOutcome.ERROR},
+        ]
+
+    def test_counts_aggregate_up_the_tree(self):
+        tree = group_by_feature(self._tests())
+        # core holds 3 tests (2 pass, 1 fail); operator holds the same 3.
+        core = tree["children"]["core"]
+        assert core["counts"]["passed"] == 2
+        assert core["counts"]["failed"] == 1
+        assert core["children"]["operator"]["counts"]["passed"] == 2
+
+    def test_leaf_holds_its_own_tests(self):
+        tree = group_by_feature(self._tests())
+        string_node = tree["children"]["core"]["children"]["operator"]["children"]["string"]
+        # string aggregates its two files; each file is the actual leaf.
+        assert string_node["counts"]["passed"] == 1
+        assert string_node["counts"]["failed"] == 1
+        assert set(string_node["children"]) == {"test_a.py", "test_b.py"}
+        leaf = string_node["children"]["test_a.py"]
+        assert leaf["counts"]["passed"] == 1 and leaf["children"] == {}
+
+    def test_ragged_depths_coexist(self):
+        # system/security is depth 2; core/operator/string is depth 3, both group.
+        tree = group_by_feature(self._tests())
+        assert tree["children"]["system"]["children"]["security"]["counts"]["error"] == 1
+
+    def test_root_totals_all_tests(self):
+        tree = group_by_feature(self._tests())
+        c = tree["counts"]
+        assert c["passed"] == 2 and c["failed"] == 1 and c["error"] == 1
+
+    def test_empty_input(self):
+        tree = group_by_feature([])
+        assert tree["children"] == {} and tree["counts"]["passed"] == 0

--- a/documentdb_tests/compatibility/result_analyzer/test_render_markdown.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_render_markdown.py
@@ -1,0 +1,72 @@
+"""Unit tests for markdown rendering of arbitrary test data.
+
+Test IDs, reasons, and tracebacks embed test inputs, which can be markup in the
+context they land in: table pipes, HTML in <summary>, backtick fences.
+"""
+
+import pytest
+
+from documentdb_tests.compatibility.result_analyzer.render_markdown import (
+    _failure_details,
+    _fenced_block,
+    _table_cell,
+    render,
+)
+
+
+def _analysis(tests):
+    """Minimal analysis dict around the given test details."""
+    return {
+        "reconciliation": {"collected": 1, "total": 1, "passed": 1},
+        "tests": tests,
+        "by_feature": {"counts": {}, "requires": set(), "children": {}},
+    }
+
+
+@pytest.mark.unit
+class TestTableCell:
+    def test_pipe_is_escaped(self):
+        assert _table_cell("t[a|b]") == "t[a\\|b]"
+
+    def test_plain_text_unchanged(self):
+        assert _table_cell("core/test_x.py::t") == "core/test_x.py::t"
+
+
+@pytest.mark.unit
+class TestFencedBlock:
+    def test_plain_traceback_gets_three_backticks(self):
+        assert _fenced_block("assert 1 == 2") == ["```", "assert 1 == 2", "```"]
+
+    def test_embedded_fence_cannot_terminate_block(self):
+        fenced = _fenced_block("data = '```'")
+        assert fenced[0] == "````" and fenced[-1] == "````"
+
+    def test_fence_always_exceeds_longest_run(self):
+        fenced = _fenced_block("x = '``````'")
+        assert fenced[0] == "`" * 7
+
+
+@pytest.mark.unit
+class TestFailureDetails:
+    def test_html_in_test_name_is_escaped(self):
+        lines = _failure_details({"name": "test_x.py::t[a<b]", "outcome": "FAIL", "error": "boom"})
+        summary = next(line for line in lines if "<summary>" in line)
+        assert "t[a&lt;b]" in summary and "t[a<b]" not in summary
+
+
+@pytest.mark.unit
+class TestRenderedTables:
+    def test_pipe_in_known_gap_does_not_split_row(self):
+        report = render(
+            _analysis([{"name": "test_x.py::t[p|q]", "outcome": "XFAIL", "xfail_reason": "a | b"}])
+        )
+        row = next(line for line in report.splitlines() if "t[p" in line)
+        # 2 columns -> exactly 3 unescaped pipes; the data pipes are escaped.
+        assert row.count("|") - row.count("\\|") == 3
+
+    def test_pipe_in_skip_reason_does_not_split_row(self):
+        report = render(
+            _analysis([{"name": "test_x.py::t", "outcome": "SKIPPED", "skip_reason": "needs x|y"}])
+        )
+        row = next(line for line in report.splitlines() if "needs x" in line)
+        assert row.count("|") - row.count("\\|") == 3

--- a/documentdb_tests/compatibility/result_analyzer/test_report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_report_content.py
@@ -9,7 +9,10 @@ from documentdb_tests.compatibility.result_analyzer.report_content import (
     cap_items,
     determine_verdict,
     group_needs_attention,
+    known_gaps,
     needs_attention,
+    pass_rate,
+    skipped_tests,
 )
 
 
@@ -92,3 +95,58 @@ class TestCapItems:
     def test_default_cap(self):
         kept, omitted = cap_items(list(range(NEEDS_ATTENTION_CAP + 3)))
         assert len(kept) == NEEDS_ATTENTION_CAP and omitted == 3
+
+
+@pytest.mark.unit
+class TestPassRate:
+    def test_all_passed_is_100(self):
+        assert pass_rate({"passed": 50, "failed": 0, "error": 0}) == "100%"
+
+    def test_never_100_when_a_failure_exists(self):
+        # 12 failures diluted by ~38k passes must NOT round up to 100%.
+        assert pass_rate({"passed": 37855, "failed": 12, "error": 0}) == "99.9%"
+
+    def test_never_100_truncates_not_rounds(self):
+        # 9999/10000 = 99.99% -> truncates to 99.9%, never 100%.
+        assert pass_rate({"passed": 9999, "failed": 1, "error": 0}) == "99.9%"
+
+    def test_error_counts_against_rate(self):
+        assert pass_rate({"passed": 9, "failed": 0, "error": 1}) == "90.0%"
+
+    def test_nothing_ran_is_dash(self):
+        assert pass_rate({"passed": 0, "failed": 0, "error": 0, "skipped": 5}) == "—"
+
+
+@pytest.mark.unit
+class TestKnownGaps:
+    def test_returns_xfailed_with_reasons(self):
+        analysis = {
+            "tests": [
+                {"name": "a", "outcome": "PASS"},
+                {"name": "b", "outcome": "XFAIL", "xfail_reason": "server bug #95"},
+                {"name": "c", "outcome": "FAIL", "failure_type": "RESULT_MISMATCH"},
+            ]
+        }
+        gaps = known_gaps(analysis)
+        assert gaps == [{"name": "b", "reason": "server bug #95"}]
+
+    def test_missing_reason_is_empty_string(self):
+        analysis = {"tests": [{"name": "b", "outcome": "XFAIL"}]}
+        assert known_gaps(analysis) == [{"name": "b", "reason": ""}]
+
+
+@pytest.mark.unit
+class TestSkippedTests:
+    def test_returns_skipped_with_reasons(self):
+        analysis = {
+            "tests": [
+                {"name": "a", "outcome": "PASS"},
+                {"name": "b", "outcome": "SKIPPED", "skip_reason": "requires auditing"},
+                {"name": "c", "outcome": "XFAIL", "xfail_reason": "gap"},
+            ]
+        }
+        assert skipped_tests(analysis) == [{"name": "b", "reason": "requires auditing"}]
+
+    def test_missing_reason_is_empty_string(self):
+        analysis = {"tests": [{"name": "b", "outcome": "SKIPPED"}]}
+        assert skipped_tests(analysis) == [{"name": "b", "reason": ""}]

--- a/documentdb_tests/compatibility/result_analyzer/test_report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_report_content.py
@@ -1,0 +1,50 @@
+"""Unit tests for report content decisions (verdict logic)."""
+
+import pytest
+
+from documentdb_tests.compatibility.result_analyzer.report_content import (
+    VERDICT_FAIL,
+    VERDICT_PASS,
+    determine_verdict,
+)
+
+
+@pytest.mark.unit
+class TestDetermineVerdict:
+    def test_clean_pass(self):
+        recon = {"passed": 10, "failed": 0, "error": 0, "xpassed": 0}
+        verdict, reason = determine_verdict(recon)
+        assert verdict == VERDICT_PASS and reason == ""
+
+    def test_failure_is_fail(self):
+        recon = {"passed": 8, "failed": 2, "error": 0, "xpassed": 0}
+        verdict, _ = determine_verdict(recon)
+        assert verdict == VERDICT_FAIL
+
+    def test_error_is_fail(self):
+        recon = {"passed": 9, "failed": 0, "error": 1, "xpassed": 0}
+        verdict, _ = determine_verdict(recon)
+        assert verdict == VERDICT_FAIL
+
+    def test_raw_xpass_is_fail_and_takes_priority(self):
+        # A raw xpassed means strict wasn't applied; results are untrustworthy.
+        recon = {"passed": 10, "failed": 0, "error": 0, "xpassed": 1}
+        verdict, reason = determine_verdict(recon)
+        assert verdict == VERDICT_FAIL and "invalid" in reason
+
+    def test_no_tests_executed_is_fail(self):
+        # Everything deselected/skipped: nothing ran, so the run has no value.
+        recon = {"passed": 0, "failed": 0, "error": 0, "xpassed": 0, "skipped": 3}
+        verdict, reason = determine_verdict(recon)
+        assert verdict == VERDICT_FAIL and "no tests ran" in reason
+
+    def test_skipped_and_xfailed_do_not_block_pass(self):
+        # A run that passed everything it ran is PASS even with skips/known gaps.
+        recon = {"passed": 5, "failed": 0, "error": 0, "xpassed": 0, "skipped": 2, "xfailed": 3}
+        verdict, _ = determine_verdict(recon)
+        assert verdict == VERDICT_PASS
+
+    def test_missing_keys_treated_as_zero_is_fail(self):
+        # Empty reconciliation -> nothing executed -> FAIL.
+        verdict, reason = determine_verdict({})
+        assert verdict == VERDICT_FAIL and "no tests ran" in reason

--- a/documentdb_tests/compatibility/result_analyzer/test_report_content.py
+++ b/documentdb_tests/compatibility/result_analyzer/test_report_content.py
@@ -3,9 +3,13 @@
 import pytest
 
 from documentdb_tests.compatibility.result_analyzer.report_content import (
+    NEEDS_ATTENTION_CAP,
     VERDICT_FAIL,
     VERDICT_PASS,
+    cap_items,
     determine_verdict,
+    group_needs_attention,
+    needs_attention,
 )
 
 
@@ -48,3 +52,43 @@ class TestDetermineVerdict:
         # Empty reconciliation -> nothing executed -> FAIL.
         verdict, reason = determine_verdict({})
         assert verdict == VERDICT_FAIL and "no tests ran" in reason
+
+
+@pytest.mark.unit
+class TestNeedsAttention:
+    def _analysis(self):
+        return {
+            "tests": [
+                {"name": "a", "outcome": "PASS"},
+                {"name": "b", "outcome": "FAIL", "failure_type": "RESULT_MISMATCH"},
+                {"name": "c", "outcome": "ERROR", "failure_type": "UNKNOWN"},
+                {"name": "d", "outcome": "SKIPPED"},
+                {"name": "e", "outcome": "XFAIL"},
+            ]
+        }
+
+    def test_includes_failures_and_errors_only(self):
+        names = {t["name"] for t in needs_attention(self._analysis())}
+        # b (FAIL) and c (ERROR); not the pass/skip/xfail.
+        assert names == {"b", "c"}
+
+    def test_grouped_by_failure_type(self):
+        grouped = group_needs_attention(self._analysis())
+        assert set(grouped) == {"RESULT_MISMATCH", "UNKNOWN"}
+        assert grouped["RESULT_MISMATCH"][0]["name"] == "b"
+        assert grouped["UNKNOWN"][0]["name"] == "c"
+
+
+@pytest.mark.unit
+class TestCapItems:
+    def test_under_cap_keeps_all(self):
+        kept, omitted = cap_items([1, 2, 3], cap=5)
+        assert kept == [1, 2, 3] and omitted == 0
+
+    def test_over_cap_trims_and_counts(self):
+        kept, omitted = cap_items(list(range(30)), cap=25)
+        assert len(kept) == 25 and omitted == 5
+
+    def test_default_cap(self):
+        kept, omitted = cap_items(list(range(NEEDS_ATTENTION_CAP + 3)))
+        assert len(kept) == NEEDS_ATTENTION_CAP and omitted == 3

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -181,6 +181,28 @@ def pytest_runtest_setup(item):
             pytest.skip(marker.kwargs.get("reason", "crashes the server"))
 
 
+@pytest.hookimpl(optionalhook=True)
+def pytest_json_runtest_metadata(item, call):
+    """Record the xfail reason in the JSON report so it isn't lost.
+
+    The reason lives on the marker but is absent from the default JSON report.
+    Keying off the resolved ``xfail`` marker (added in setup above for the
+    matching engine) captures it only when xfail is actually in effect, and
+    covers both the xfailed test and a strict-xpass that became a failure.
+
+    ``optionalhook`` so this is ignored when pytest-json-report isn't active
+    (e.g. a plain unit-test run without --json-report), rather than erroring as
+    an unknown hook.
+    """
+    if call.when != "setup":
+        return {}
+    marker = item.get_closest_marker("xfail")
+    if marker is None:
+        return {}
+    reason = marker.kwargs.get("reason")
+    return {"xfail_reason": reason} if reason else {}
+
+
 @pytest.fixture(scope="session")
 def engine_client(request):
     """

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 # Enable assertion rewriting BEFORE importing framework modules
 pytest.register_assert_rewrite("documentdb_tests.framework.assertions")
 
+import warnings  # noqa: E402
 from pathlib import Path  # noqa: E402
 
 from documentdb_tests.framework import fixtures  # noqa: E402
@@ -370,18 +371,30 @@ def _write_deselected_sidecar(config, deselected_reasons: dict) -> None:
     lets the result analyzer explain the collected-vs-executed gap — e.g. which
     features were not applicable to this target — rather than showing a bare
     count. No-op when the JSON report isn't enabled.
+
+    The report's directory may not exist yet: this runs at collection time, while
+    pytest-json-report creates the directory later, when it writes the report at
+    session end. Create it here so the sidecar isn't lost.
     """
     report_path = getattr(config.option, "json_report_file", None)
     if not report_path:
         return
     import json
 
-    sidecar = f"{report_path}.deselected.json"
+    sidecar = Path(f"{report_path}.deselected.json")
     try:
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
         with open(sidecar, "w") as f:
             json.dump(deselected_reasons, f)
-    except OSError:
-        pass
+    except OSError as exc:
+        # Warn rather than fail: the sidecar only enriches the report, so a run
+        # should still complete without it. Staying silent here once hid its
+        # absence for a whole CI cycle, leaving the report quietly incomplete.
+        warnings.warn(
+            f"Could not write the deselected-tests sidecar {sidecar}: {exc}. "
+            "The report will not be able to explain deselected (unsupported) tests.",
+            stacklevel=2,
+        )
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -356,6 +356,29 @@ def register_db_cleanup(engine_client):
             fixtures.cleanup_database(engine_client, name)
 
 
+def _write_deselected_sidecar(config, deselected_reasons: dict) -> None:
+    """
+    Record why tests were deselected, alongside the JSON report.
+
+    Deselected tests are dropped before the run, so they never appear in the
+    pytest JSON report. Writing a sidecar next to it (``<report>.deselected.json``)
+    lets the result analyzer explain the collected-vs-executed gap — e.g. which
+    features were not applicable to this target — rather than showing a bare
+    count. No-op when the JSON report isn't enabled.
+    """
+    report_path = getattr(config.option, "json_report_file", None)
+    if not report_path:
+        return
+    import json
+
+    sidecar = f"{report_path}.deselected.json"
+    try:
+        with open(sidecar, "w") as f:
+            json.dump(deselected_reasons, f)
+    except OSError:
+        pass
+
+
 def pytest_collection_modifyitems(session, config, items):
     """
     Combined pytest hook to validate test structure, format, and framework invariants.
@@ -377,6 +400,8 @@ def pytest_collection_modifyitems(session, config, items):
     capabilities_by_target: dict[str, frozenset[str]] = {}
     kept: list = []
     requires_deselected: list = []
+    # nodeid -> the requirements the target did not meet, for the report sidecar.
+    deselected_reasons: dict[str, dict] = {}
     for item in items:
         marker = item.get_closest_marker(REQUIRES_MARKER)
         if marker is None or not marker.kwargs:
@@ -392,11 +417,13 @@ def pytest_collection_modifyitems(session, config, items):
             capabilities_by_target[target.connection_string] = capabilities
         if unmet_requirements(marker.kwargs, capabilities):
             requires_deselected.append(item)
+            deselected_reasons[item.nodeid] = unmet_requirements(marker.kwargs, capabilities)
         else:
             kept.append(item)
     if requires_deselected:
         config.hook.pytest_deselected(items=requires_deselected)
         items[:] = kept
+        _write_deselected_sidecar(config, deselected_reasons)
 
     # Deselect no_parallel tests when running under xdist
     is_xdist = bool(getattr(config.option, "numprocesses", None)) or hasattr(config, "workerinput")

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -377,7 +377,9 @@ def _write_deselected_sidecar(config, deselected_reasons: dict) -> None:
     session end. Create it here so the sidecar isn't lost.
     """
     report_path = getattr(config.option, "json_report_file", None)
-    if not report_path:
+    # json_report_file defaults to ".report.json" even when the plugin is off,
+    # so gate on the --json-report flag itself.
+    if not getattr(config.option, "json_report", False) or not report_path:
         return
     import json
 
@@ -441,7 +443,8 @@ def pytest_collection_modifyitems(session, config, items):
     if requires_deselected:
         config.hook.pytest_deselected(items=requires_deselected)
         items[:] = kept
-        _write_deselected_sidecar(config, deselected_reasons)
+    # Written even when empty, or a stale sidecar from a previous run survives.
+    _write_deselected_sidecar(config, deselected_reasons)
 
     # Deselect no_parallel tests when running under xdist
     is_xdist = bool(getattr(config.option, "numprocesses", None)) or hasattr(config, "workerinput")
@@ -680,6 +683,11 @@ def pytest_sessionfinish(session, exitstatus):
             print(f"⚠️  Failed to merge JSON reports: {e}", file=sys.stderr)
         finally:
             os.unlink(phase2_json)
+            # Phase 2 collection writes a redundant sidecar next to its temp
+            # report; clean it up too.
+            phase2_sidecar = f"{phase2_json}.deselected.json"
+            if os.path.exists(phase2_sidecar):
+                os.unlink(phase2_sidecar)
 
     if phase2_junit and os.path.exists(phase2_junit):
         try:

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -166,10 +166,15 @@ def pytest_runtest_setup(item):
     engine = target.engine if target is not None else None
     for marker in item.iter_markers("engine_xfail"):
         if engine == marker.kwargs.get("engine"):
+            # strict=True so a documented gap that the server has since fixed
+            # becomes a hard failure (an unexpected pass), not a silently
+            # tolerated xpass. That forces the stale marker to be removed and the
+            # test to resume guarding real behavior.
             item.add_marker(
                 pytest.mark.xfail(
                     reason=marker.kwargs.get("reason", ""),
                     raises=marker.kwargs.get("raises", AssertionError),
+                    strict=True,
                 )
             )
     # A crash test kills the server, so it is skipped against the engine it

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -29,6 +29,9 @@ from documentdb_tests.framework.large_payload_guard import (  # noqa: E402
     PARAM_SIZE_LIMIT_BYTES,
     exceeds_size_limit,
 )
+from documentdb_tests.framework.marker_reason_validator import (  # noqa: E402
+    validate_marker_reasons,
+)
 from documentdb_tests.framework.preconditions import (  # noqa: E402
     REQUIRES_MARKER,
     detect_capabilities,
@@ -389,6 +392,7 @@ def pytest_collection_modifyitems(session, config, items):
 
     structure_errors = []
     format_errors = {}
+    marker_reason_errors = {}
 
     # Validate file structure for all files under "tests" folder
     if items:
@@ -410,6 +414,9 @@ def pytest_collection_modifyitems(session, config, items):
         file_errors = validate_test_format(file_path)
         if file_errors:
             format_errors[file_path] = file_errors
+        reason_errors = validate_marker_reasons(file_path)
+        if reason_errors:
+            marker_reason_errors[file_path] = reason_errors
 
     # Validate framework error code invariants
     structure_errors.extend(validate_error_codes_sorted())
@@ -430,7 +437,7 @@ def pytest_collection_modifyitems(session, config, items):
                 )
                 break
 
-    if structure_errors or format_errors or large_param_errors:
+    if structure_errors or format_errors or marker_reason_errors or large_param_errors:
         import sys
 
         if structure_errors:
@@ -444,6 +451,20 @@ def pytest_collection_modifyitems(session, config, items):
                 print(f"\n{file_path}:", file=sys.stderr)
                 print("\n".join(file_errors), file=sys.stderr)
             print("\nSee docs/testing/TEST_FORMAT.md for rules.\n", file=sys.stderr)
+
+        if marker_reason_errors:
+            print("\n❌ Marker Reason Violations:", file=sys.stderr)
+            for file_path, file_errors in marker_reason_errors.items():
+                print(f"\n{file_path}:", file=sys.stderr)
+                print("\n".join(file_errors), file=sys.stderr)
+            print(
+                "\nMarkers that skip or reclassify a test (skip/skipif/xfail/"
+                "engine_xfail/engine_xcrash) must carry a reason=, and runtime "
+                "pytest.skip()/fail()/xfail() calls must pass a message, so the "
+                "outcome is never unexplained. See docs/testing/TEST_FORMAT.md "
+                "for rules.\n",
+                file=sys.stderr,
+            )
 
         if large_param_errors:
             print("\n❌ Large Test Payloads:", file=sys.stderr)

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -558,7 +558,9 @@ def _merge_json_reports(phase1_path, phase2_path):
     p1["duration"] = p1.get("duration", 0) + p2.get("duration", 0)
     p1_summary = p1.setdefault("summary", {})
     p2_summary = p2.get("summary", {})
-    for key in ("passed", "failed", "error", "skipped", "total"):
+    # Sum every per-test outcome bucket; omitting one leaves the merged summary
+    # inconsistent with the merged "tests" array (xfailed/xpassed were once lost).
+    for key in ("passed", "failed", "error", "skipped", "xfailed", "xpassed", "total"):
         if key in p2_summary:
             p1_summary[key] = p1_summary.get(key, 0) + p2_summary[key]
     # Phase 2 runs without xdist, so its collected reflects the true count

--- a/documentdb_tests/conftest.py
+++ b/documentdb_tests/conftest.py
@@ -375,6 +375,10 @@ def _write_deselected_sidecar(config, deselected_reasons: dict) -> None:
     The report's directory may not exist yet: this runs at collection time, while
     pytest-json-report creates the directory later, when it writes the report at
     session end. Create it here so the sidecar isn't lost.
+
+    Under xdist every worker writes this same path with identical contents, but
+    concurrent truncate-and-write can tear the file, so write a per-process temp
+    file and os.replace it into place.
     """
     report_path = getattr(config.option, "json_report_file", None)
     # json_report_file defaults to ".report.json" even when the plugin is off,
@@ -382,16 +386,20 @@ def _write_deselected_sidecar(config, deselected_reasons: dict) -> None:
     if not getattr(config.option, "json_report", False) or not report_path:
         return
     import json
+    import os
 
     sidecar = Path(f"{report_path}.deselected.json")
+    temp_path = f"{sidecar}.{os.getpid()}.tmp"
     try:
         sidecar.parent.mkdir(parents=True, exist_ok=True)
-        with open(sidecar, "w") as f:
+        with open(temp_path, "w") as f:
             json.dump(deselected_reasons, f)
+        os.replace(temp_path, sidecar)
     except OSError as exc:
         # Warn rather than fail: the sidecar only enriches the report, so a run
         # should still complete without it. Staying silent here once hid its
         # absence for a whole CI cycle, leaving the report quietly incomplete.
+        Path(temp_path).unlink(missing_ok=True)
         warnings.warn(
             f"Could not write the deselected-tests sidecar {sidecar}: {exc}. "
             "The report will not be able to explain deselected (unsupported) tests.",

--- a/documentdb_tests/framework/infra_exceptions.py
+++ b/documentdb_tests/framework/infra_exceptions.py
@@ -18,6 +18,7 @@ INFRA_EXCEPTION_NAMES = {
     "pymongo.errors.NetworkTimeout",
     "pymongo.errors.AutoReconnect",
     "pymongo.errors.ExecutionTimeout",
+    "pymongo.errors._OperationCancelled",
 }
 
 

--- a/documentdb_tests/framework/marker_reason_validator.py
+++ b/documentdb_tests/framework/marker_reason_validator.py
@@ -72,9 +72,9 @@ def _runtime_skip_function(node: ast.Call) -> str | None:
     """
     func = node.func
     if isinstance(func, ast.Attribute) and func.attr in RUNTIME_SKIP_FUNCTIONS:
-        # Exclude marker attributes (``pytest.mark.skip``); those are handled
-        # separately and would otherwise be double-flagged.
-        if isinstance(func.value, ast.Attribute) and func.value.attr == "mark":
+        # Must be on ``pytest`` itself: a PyMongo cursor's ``.skip(n)`` is
+        # unrelated. Also excludes ``pytest.mark.skip``, handled above.
+        if not (isinstance(func.value, ast.Name) and func.value.id == "pytest"):
             return None
         return func.attr
     if isinstance(func, ast.Name) and func.id in RUNTIME_SKIP_FUNCTIONS:

--- a/documentdb_tests/framework/marker_reason_validator.py
+++ b/documentdb_tests/framework/marker_reason_validator.py
@@ -1,0 +1,141 @@
+"""
+Marker reason validator.
+
+Enforces that markers which suppress or reclassify a test's outcome always carry
+an explanation, so a run's skipped/xfailed tests are never unexplained. Checked
+statically at collection time alongside the other framework invariants.
+
+Covers two forms:
+
+- **Markers** — ``@pytest.mark.skip`` / ``skipif`` / ``xfail`` and this repo's
+  ``engine_xfail`` / ``engine_xcrash`` variants, via their ``reason=``.
+- **Runtime calls** — ``pytest.skip(...)`` / ``fail(...)`` / ``xfail(...)``, via
+  their positional message or ``reason=`` / ``msg=``.
+"""
+
+from __future__ import annotations
+
+import ast
+
+# Markers that must justify why they suppress or reclassify an outcome.
+MARKERS_REQUIRING_REASON = frozenset({"skip", "skipif", "xfail", "engine_xfail", "engine_xcrash"})
+
+# Bare (uncalled) decorator form is only meaningful for these two.
+BARE_DECORATOR_MARKERS = frozenset({"skip", "xfail"})
+
+# Runtime functions that suppress/reclassify an outcome and take a message.
+RUNTIME_SKIP_FUNCTIONS = frozenset({"skip", "fail", "xfail"})
+
+
+def _marker_name(node: ast.expr) -> str | None:
+    """
+    Return the marker name if ``node`` refers to a ``*.mark.<name>`` attribute.
+
+    Matches ``pytest.mark.xfail`` and friends regardless of the module prefix, so
+    it works for decorators, ``marks=`` entries, and module-level constants alike.
+    """
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "mark"
+    ):
+        return node.attr
+    return None
+
+
+def _is_valid_explanation(value: ast.expr) -> bool:
+    """
+    An explanation is valid when present and, if a string literal, non-empty.
+
+    A non-literal (Name / f-string / concatenation) is accepted because its value
+    can't be resolved statically.
+    """
+    if isinstance(value, ast.Constant):
+        return isinstance(value.value, str) and value.value.strip() != ""
+    return True
+
+
+def _marker_has_valid_reason(call: ast.Call) -> bool:
+    """A marker's ``reason=`` keyword must be present and a valid explanation."""
+    for keyword in call.keywords:
+        if keyword.arg == "reason":
+            return _is_valid_explanation(keyword.value)
+    return False
+
+
+def _runtime_skip_function(node: ast.Call) -> str | None:
+    """
+    Return the function name for a ``pytest.skip``/``fail``/``xfail`` call.
+
+    Matches both ``pytest.skip(...)`` (attribute) and a bare ``skip(...)``
+    imported via ``from pytest import skip``.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr in RUNTIME_SKIP_FUNCTIONS:
+        # Exclude marker attributes (``pytest.mark.skip``); those are handled
+        # separately and would otherwise be double-flagged.
+        if isinstance(func.value, ast.Attribute) and func.value.attr == "mark":
+            return None
+        return func.attr
+    if isinstance(func, ast.Name) and func.id in RUNTIME_SKIP_FUNCTIONS:
+        return func.id
+    return None
+
+
+def _runtime_call_has_message(call: ast.Call) -> bool:
+    """A runtime skip/fail/xfail call needs a present, non-empty-if-literal message."""
+    if call.args:
+        return _is_valid_explanation(call.args[0])
+    for keyword in call.keywords:
+        if keyword.arg in ("reason", "msg"):
+            return _is_valid_explanation(keyword.value)
+    return False
+
+
+def validate_marker_reasons(file_path: str) -> list[str]:
+    """
+    Validate that outcome-suppressing markers carry a reason.
+
+    Returns:
+        List of error messages for violations (empty if the file is clean or
+        cannot be parsed).
+    """
+    errors: list[str] = []
+
+    try:
+        with open(file_path) as f:
+            tree = ast.parse(f.read(), filename=file_path)
+    except Exception:
+        return errors  # Skip files that can't be parsed
+
+    # Called form: @pytest.mark.xfail(...), marks=pytest.mark.engine_xfail(...),
+    # or module-level constants like X = pytest.mark.engine_xfail(...).
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _marker_name(node.func)
+        if name in MARKERS_REQUIRING_REASON and not _marker_has_valid_reason(node):
+            errors.append(
+                f"  Line {node.lineno}: @pytest.mark.{name}(...) must pass a non-empty reason=."
+            )
+        # Runtime call form: pytest.skip(...) / fail(...) / xfail(...).
+        runtime_name = _runtime_skip_function(node)
+        if runtime_name is not None and not _runtime_call_has_message(node):
+            errors.append(
+                f"  Line {node.lineno}: pytest.{runtime_name}() must be called with "
+                f"a non-empty message explaining why."
+            )
+
+    # Bare decorator form: @pytest.mark.skip / @pytest.mark.xfail (no reason at all).
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for decorator in node.decorator_list:
+            name = _marker_name(decorator)
+            if name in BARE_DECORATOR_MARKERS:
+                errors.append(
+                    f"  Line {decorator.lineno}: @pytest.mark.{name} used without a "
+                    f"reason= (add @pytest.mark.{name}(reason=...))."
+                )
+
+    return errors

--- a/documentdb_tests/framework/test_marker_reason_validator.py
+++ b/documentdb_tests/framework/test_marker_reason_validator.py
@@ -1,0 +1,98 @@
+"""Unit tests for the marker reason validator."""
+
+import pytest
+
+from documentdb_tests.framework.marker_reason_validator import validate_marker_reasons
+
+
+def _write(tmp_path, source: str) -> str:
+    """Write source to a temp file and return its path."""
+    file_path = tmp_path / "test_sample.py"
+    file_path.write_text(source)
+    return str(file_path)
+
+
+@pytest.mark.unit
+class TestMarkerReasonValidator:
+    def test_skip_with_reason_is_clean(self, tmp_path):
+        src = '@pytest.mark.skip(reason="needs Atlas search")\ndef test_a():\n    pass\n'
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_skip_without_reason_is_flagged(self, tmp_path):
+        src = "@pytest.mark.skip()\ndef test_a():\n    pass\n"
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "skip" in errors[0]
+
+    def test_bare_skip_decorator_is_flagged(self, tmp_path):
+        src = "@pytest.mark.skip\ndef test_a():\n    pass\n"
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "without a reason" in errors[0]
+
+    def test_empty_reason_is_flagged(self, tmp_path):
+        src = '@pytest.mark.xfail(reason="   ")\ndef test_a():\n    pass\n'
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "xfail" in errors[0]
+
+    def test_none_reason_is_flagged(self, tmp_path):
+        src = "@pytest.mark.xfail(reason=None)\ndef test_a():\n    pass\n"
+        assert len(validate_marker_reasons(_write(tmp_path, src))) == 1
+
+    def test_variable_reason_is_accepted(self, tmp_path):
+        # A non-literal reason (e.g. a shared constant) can't be resolved
+        # statically, so it's accepted as present.
+        src = (
+            "_R = 'server crashes on views'\n"
+            '@pytest.mark.engine_xcrash(engine="mongodb", reason=_R)\n'
+            "def test_a():\n    pass\n"
+        )
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_engine_xfail_in_marks_with_reason_is_clean(self, tmp_path):
+        src = (
+            "params = [\n"
+            "    pytest.param(1, marks=pytest.mark.engine_xfail(\n"
+            '        engine="mongodb", reason="known incompatibility")),\n'
+            "]\n"
+        )
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_engine_xfail_in_marks_without_reason_is_flagged(self, tmp_path):
+        src = (
+            "params = [\n"
+            '    pytest.param(1, marks=pytest.mark.engine_xfail(engine="mongodb")),\n'
+            "]\n"
+        )
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "engine_xfail" in errors[0]
+
+    def test_module_level_constant_marker_is_checked(self, tmp_path):
+        src = 'X = pytest.mark.engine_xfail(engine="mongodb")\n'
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "engine_xfail" in errors[0]
+
+    def test_runtime_skip_with_literal_is_clean(self, tmp_path):
+        src = 'def test_a():\n    pytest.skip("no system namespace found")\n'
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_runtime_skip_with_fstring_is_clean(self, tmp_path):
+        # A runtime message is expected to embed dynamic context; presence is enough.
+        src = 'def test_a():\n    pytest.skip(f"unrecognized {x!r}")\n'
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_runtime_skip_without_argument_is_flagged(self, tmp_path):
+        src = "def test_a():\n    pytest.skip()\n"
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "pytest.skip()" in errors[0]
+
+    def test_runtime_skip_with_empty_literal_is_flagged(self, tmp_path):
+        src = 'def test_a():\n    pytest.skip("")\n'
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 1 and "pytest.skip()" in errors[0]
+
+    def test_runtime_fail_and_xfail_without_argument_are_flagged(self, tmp_path):
+        src = "def test_a():\n    pytest.fail()\ndef test_b():\n    pytest.xfail()\n"
+        errors = validate_marker_reasons(_write(tmp_path, src))
+        assert len(errors) == 2
+
+    def test_unparseable_file_is_skipped(self, tmp_path):
+        assert validate_marker_reasons(_write(tmp_path, "def (:\n")) == []

--- a/documentdb_tests/framework/test_marker_reason_validator.py
+++ b/documentdb_tests/framework/test_marker_reason_validator.py
@@ -94,5 +94,18 @@ class TestMarkerReasonValidator:
         errors = validate_marker_reasons(_write(tmp_path, src))
         assert len(errors) == 2
 
+    def test_cursor_skip_is_not_a_pytest_skip(self, tmp_path):
+        # A PyMongo cursor's .skip(n) is pagination, not an outcome suppression.
+        src = "def test_a(collection):\n    docs = list(collection.find({}).skip(2))\n"
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_chained_cursor_skip_is_not_flagged(self, tmp_path):
+        src = "def test_a(collection):\n    collection.find({}).skip(3).limit(2)\n"
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
+    def test_unrelated_fail_method_is_not_flagged(self, tmp_path):
+        src = "class T:\n    def test_a(self):\n        self.fail()\n"
+        assert validate_marker_reasons(_write(tmp_path, src)) == []
+
     def test_unparseable_file_is_skipped(self, tmp_path):
         assert validate_marker_reasons(_write(tmp_path, "def (:\n")) == []

--- a/documentdb_tests/test_conftest_merge.py
+++ b/documentdb_tests/test_conftest_merge.py
@@ -1,0 +1,56 @@
+"""Unit tests for merging Phase 2 (no_parallel) JSON reports into Phase 1."""
+
+import json
+
+import pytest
+
+from documentdb_tests.conftest import _merge_json_reports
+
+
+def _merge(tmp_path, p1_summary, p2_summary):
+    """Write two minimal reports, merge, and return the merged summary."""
+    p1 = tmp_path / "p1.json"
+    p2 = tmp_path / "p2.json"
+    p1.write_text(json.dumps({"summary": p1_summary, "tests": [], "duration": 1.0}))
+    p2.write_text(json.dumps({"summary": p2_summary, "tests": [], "duration": 1.0}))
+    _merge_json_reports(str(p1), str(p2))
+    return json.loads(p1.read_text())["summary"]
+
+
+@pytest.mark.unit
+class TestMergeJsonReports:
+    def test_outcome_buckets_are_summed(self, tmp_path):
+        merged = _merge(
+            tmp_path,
+            {"collected": 10, "total": 8, "passed": 7, "failed": 1},
+            {"collected": 10, "total": 2, "passed": 1, "failed": 1},
+        )
+        assert merged["passed"] == 8 and merged["failed"] == 2 and merged["total"] == 10
+
+    def test_xfailed_and_xpassed_are_summed(self, tmp_path):
+        merged = _merge(
+            tmp_path,
+            {"collected": 10, "total": 8, "passed": 7, "xfailed": 1},
+            {"collected": 10, "total": 2, "passed": 1, "xfailed": 1},
+        )
+        assert merged["xfailed"] == 2
+
+    def test_collected_taken_from_phase2(self, tmp_path):
+        # Phase 2 runs without xdist, so its collected count is the true
+        # pre-deselection total.
+        merged = _merge(
+            tmp_path,
+            {"collected": 8, "total": 8, "passed": 8},
+            {"collected": 10, "total": 2, "passed": 2},
+        )
+        assert merged["collected"] == 10
+
+    def test_merged_summary_reconciles_with_no_deselection(self, tmp_path):
+        # collected == total after merging, so no_parallel tests are not
+        # misreported as unsupported.
+        merged = _merge(
+            tmp_path,
+            {"collected": 8, "total": 8, "passed": 8},
+            {"collected": 10, "total": 2, "passed": 2},
+        )
+        assert merged["collected"] == merged["total"] == 10

--- a/documentdb_tests/test_conftest_sidecar.py
+++ b/documentdb_tests/test_conftest_sidecar.py
@@ -1,0 +1,48 @@
+"""Unit tests for the deselected-tests sidecar written at collection time."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from documentdb_tests.conftest import _write_deselected_sidecar
+
+
+def _config(report_path, json_report=True):
+    """Minimal stand-in for pytest config; only the json-report options are read."""
+    return SimpleNamespace(
+        option=SimpleNamespace(json_report=json_report, json_report_file=report_path)
+    )
+
+
+@pytest.mark.unit
+class TestWriteDeselectedSidecar:
+    def test_writes_reasons_next_to_report(self, tmp_path):
+        report = tmp_path / "report.json"
+        reasons = {"tests/x/test_a.py::t": {"replica_set": True}}
+        _write_deselected_sidecar(_config(str(report)), reasons)
+        sidecar = tmp_path / "report.json.deselected.json"
+        assert json.loads(sidecar.read_text()) == reasons
+
+    def test_empty_reasons_overwrite_stale_sidecar(self, tmp_path):
+        report = tmp_path / "report.json"
+        sidecar = tmp_path / "report.json.deselected.json"
+        sidecar.write_text(json.dumps({"tests/x/test_a.py::t": {"replica_set": True}}))
+        _write_deselected_sidecar(_config(str(report)), {})
+        assert json.loads(sidecar.read_text()) == {}
+
+    def test_noop_without_json_report(self, tmp_path):
+        _write_deselected_sidecar(_config(None), {"n": {"cap": True}})
+        assert list(tmp_path.iterdir()) == []
+
+    def test_noop_when_plugin_inactive(self, tmp_path):
+        # json_report_file has a default even when --json-report isn't passed.
+        report = tmp_path / "report.json"
+        _write_deselected_sidecar(_config(str(report), json_report=False), {"n": {"cap": True}})
+        assert list(tmp_path.iterdir()) == []
+
+    def test_creates_missing_report_directory(self, tmp_path):
+        # Collection runs before pytest-json-report creates the directory.
+        report = tmp_path / "not-yet" / "report.json"
+        _write_deselected_sidecar(_config(str(report)), {})
+        assert (tmp_path / "not-yet" / "report.json.deselected.json").exists()

--- a/documentdb_tests/test_conftest_sidecar.py
+++ b/documentdb_tests/test_conftest_sidecar.py
@@ -46,3 +46,9 @@ class TestWriteDeselectedSidecar:
         report = tmp_path / "not-yet" / "report.json"
         _write_deselected_sidecar(_config(str(report)), {})
         assert (tmp_path / "not-yet" / "report.json.deselected.json").exists()
+
+    def test_leaves_no_temp_files_behind(self, tmp_path):
+        report = tmp_path / "report.json"
+        _write_deselected_sidecar(_config(str(report)), {"n": {"cap": True}})
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []


### PR DESCRIPTION
This change reworks the CI test report to provide as much information as possible at a glance.

The main aims were to:

- Quickly provide information about failures and what caused them
- Provide a way to explore test results for arbitrary subsets of tests (based on repo structure, not pytest tags)

The new report format is easiest to look at in the form of real test scenarios I ran on CI during testing. These are contrived failures for the purpose of generating the specific report types.

| Scenario | Run | Shows |
|---|---|---|
| Baseline, all passing | [30304940350](https://github.com/documentdb/functional-tests/actions/runs/30304940350) | all tests passing with a clear success marker, and optional breakdown of per-test folder structure |
| Test failures | [30308231576](https://github.com/documentdb/functional-tests/actions/runs/30308231576) | clear failure marker, with "needs attention" breakdown per failure |
| Large number of test failures | [30310219663](https://github.com/documentdb/functional-tests/actions/runs/30310219663) | too many errors are cut off, only a subset shown |
| Strict xpass | [30314372700](https://github.com/documentdb/functional-tests/actions/runs/30314372700) | if an `xfail` test starts unexpectedly passing, then it appears in the "needs attention" section |

### Analyzer correctness fixes along the way

- Skip and `xfail` reasons are now mandatory and enforced by the validator, to provide better info in the report
- The previous tag-based grouping is no longer necessary and were removed
- `xpass` is now configured as strict, meaning `xfail` tests will now fail if they unexpectedly start to pass

Fixes #121 