### PR TITLE
Add $addToSet window operator compatibility tests

### DIFF
--- a/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_argument_validation.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_argument_validation.py
@@ -1,0 +1,303 @@
+"""
+Tests for $addToSet argument validation in window context.
+
+$addToSet accepts any expression as its single argument and collects the value,
+so this covers the accepted expression forms (field path, operator, literal,
+array, object) and the output-field / expression shapes that produce parse
+errors. Set-valued results are compared with ignore_order_in=["result"].
+"""
+
+from documentdb_tests.compatibility.tests.core.operator.window.utils.window_test_case import (
+    run_window_operator,
+)
+from documentdb_tests.framework.assertions import assertFailureCode, assertSuccess
+from documentdb_tests.framework.error_codes import (
+    EXPRESSION_OBJECT_MULTIPLE_FIELDS_ERROR,
+    FAILED_TO_PARSE_ERROR,
+    FIELD_PATH_EMPTY_COMPONENT_ERROR,
+    UNRECOGNIZED_EXPRESSION_ERROR,
+)
+from documentdb_tests.framework.executor import execute_command
+
+WHOLE = {"documents": ["unbounded", "unbounded"]}
+
+TWO_DOCS = [
+    {"_id": 1, "partition": "A", "value": 10},
+    {"_id": 2, "partition": "A", "value": 20},
+]
+
+SINGLE_DOC = [{"_id": 1, "partition": "A", "value": 10}]
+
+# Property [Valid Expression Forms]: $addToSet accepts any expression and collects its value.
+
+
+def test_addToSet_field_path_expression(collection):
+    """$addToSet accepts a field path expression and collects the field values."""
+    result = run_window_operator(collection, "$addToSet", TWO_DOCS, WHOLE, expression="$value")
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "result": [10, 20]},
+        {"_id": 2, "partition": "A", "value": 20, "result": [10, 20]},
+    ]
+    assertSuccess(
+        result, expected, msg="field path expression accepted", ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_operator_expression(collection):
+    """$addToSet accepts an operator expression and collects the computed values."""
+    result = run_window_operator(
+        collection, "$addToSet", TWO_DOCS, WHOLE, expression={"$add": ["$value", 1]}
+    )
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "result": [11, 21]},
+        {"_id": 2, "partition": "A", "value": 20, "result": [11, 21]},
+    ]
+    assertSuccess(result, expected, msg="operator expression accepted", ignore_order_in=["result"])
+
+
+def test_addToSet_literal_constant_expression(collection):
+    """$addToSet with a literal constant — every row contributes the same value, deduped to one."""
+    result = run_window_operator(
+        collection, "$addToSet", TWO_DOCS, WHOLE, expression={"$literal": 42}
+    )
+    expected = [
+        {"_id": 1, "partition": "A", "value": 10, "result": [42]},
+        {"_id": 2, "partition": "A", "value": 20, "result": [42]},
+    ]
+    assertSuccess(
+        result, expected, msg="literal constant collected and deduped", ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_array_expression(collection):
+    """$addToSet with an array expression collects the whole array as a single element."""
+    docs = [
+        {"_id": 1, "partition": "A", "x": 10, "y": 20},
+        {"_id": 2, "partition": "A", "x": 10, "y": 99},
+    ]
+    result = run_window_operator(collection, "$addToSet", docs, WHOLE, expression=["$x", "$y"])
+    expected = [
+        {"_id": 1, "partition": "A", "x": 10, "y": 20, "result": [[10, 20], [10, 99]]},
+        {"_id": 2, "partition": "A", "x": 10, "y": 99, "result": [[10, 20], [10, 99]]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="array expression collected as one element",
+        ignore_order_in=["result"],
+    )
+
+
+def test_addToSet_object_expression(collection):
+    """$addToSet with an object expression collects the object; equal objects dedup to one."""
+    docs = [
+        {"_id": 1, "partition": "A", "x": 10},
+        {"_id": 2, "partition": "A", "x": 10},
+    ]
+    result = run_window_operator(collection, "$addToSet", docs, WHOLE, expression={"a": "$x"})
+    expected = [
+        {"_id": 1, "partition": "A", "x": 10, "result": [{"a": 10}]},
+        {"_id": 2, "partition": "A", "x": 10, "result": [{"a": 10}]},
+    ]
+    assertSuccess(
+        result, expected, msg="object expression collected and deduped", ignore_order_in=["result"]
+    )
+
+
+# Property [Invalid Argument Shapes - Parse Errors]: inputs that produce errors at parse time.
+
+
+def test_addToSet_unknown_key_in_output_field_errors(collection):
+    """Unknown key alongside $addToSet in output field spec produces parse error."""
+    collection.insert_many(SINGLE_DOC)
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "result": {
+                                "$addToSet": "$value",
+                                "window": WHOLE,
+                                "unknownKey": 1,
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(result, FAILED_TO_PARSE_ERROR, msg="unknown key alongside $addToSet rejected")
+
+
+def test_addToSet_unknown_key_errors_on_empty_collection(collection):
+    """Parse-time error fires on an empty collection — no documents needed."""
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "result": {
+                                "$addToSet": "$value",
+                                "window": WHOLE,
+                                "unknownKey": 1,
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(
+        result, FAILED_TO_PARSE_ERROR, msg="parse-time error fires on empty collection"
+    )
+
+
+def test_addToSet_multiple_accumulators_in_output_field_errors(collection):
+    """Multiple accumulators in the same output field spec produces parse error."""
+    collection.insert_many(SINGLE_DOC)
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "result": {
+                                "$addToSet": "$value",
+                                "$sum": "$value",
+                                "window": WHOLE,
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(
+        result, FAILED_TO_PARSE_ERROR, msg="multiple accumulators in output field rejected"
+    )
+
+
+def test_addToSet_no_accumulator_in_output_field_errors(collection):
+    """Output field with no accumulator (only window key) produces parse error."""
+    collection.insert_many(SINGLE_DOC)
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {"result": {"window": WHOLE}},
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(result, FAILED_TO_PARSE_ERROR, msg="no accumulator in output field rejected")
+
+
+def test_addToSet_multi_key_expression_object_errors(collection):
+    """$addToSet with a multi-key expression object (ambiguous) produces error."""
+    collection.insert_many(SINGLE_DOC)
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "result": {
+                                "$addToSet": {"$add": [1, 2], "$subtract": [3, 1]},
+                                "window": WHOLE,
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(
+        result, EXPRESSION_OBJECT_MULTIPLE_FIELDS_ERROR, msg="multi-key expression object rejected"
+    )
+
+
+def test_addToSet_unrecognized_expression_operator_errors(collection):
+    """$addToSet with an unrecognized expression operator produces error."""
+    collection.insert_many(SINGLE_DOC)
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "result": {
+                                "$addToSet": {"$unknownOp": "$value"},
+                                "window": WHOLE,
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(
+        result, UNRECOGNIZED_EXPRESSION_ERROR, msg="unrecognized expression operator rejected"
+    )
+
+
+def test_addToSet_field_path_empty_component_errors(collection):
+    """$addToSet with a field path containing an empty component produces error."""
+    collection.insert_many(SINGLE_DOC)
+    result = execute_command(
+        collection,
+        {
+            "aggregate": collection.name,
+            "pipeline": [
+                {
+                    "$setWindowFields": {
+                        "partitionBy": "$partition",
+                        "sortBy": {"_id": 1},
+                        "output": {
+                            "result": {
+                                "$addToSet": "$a..b",
+                                "window": WHOLE,
+                            }
+                        },
+                    }
+                }
+            ],
+            "cursor": {},
+        },
+    )
+    assertFailureCode(
+        result, FIELD_PATH_EMPTY_COMPONENT_ERROR, msg="field path with empty component rejected"
+    )

--- a/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_field_paths.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_field_paths.py
@@ -1,0 +1,173 @@
+"""
+Tests for $addToSet with nested field paths and array traversal.
+
+Covers dotted paths, missing intermediate paths, null-valued vs missing fields,
+top-level arrays collected whole, array-of-objects traversal, and numeric path
+components. $addToSet collects the resolved value of any type; a missing field
+contributes nothing while an explicit null is collected. Results compared with
+ignore_order_in=["result"].
+"""
+
+from documentdb_tests.compatibility.tests.core.operator.window.utils.window_test_case import (
+    run_window_operator,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+
+WHOLE = {"documents": ["unbounded", "unbounded"]}
+
+
+# Property [Dotted Field Path]: $addToSet resolves nested values via a dotted path.
+
+
+def test_addToSet_dotted_field_path(collection):
+    """$addToSet with a dotted field path collects nested document values."""
+    docs = [
+        {"_id": 1, "partition": "A", "data": {"metrics": {"value": 10}}},
+        {"_id": 2, "partition": "A", "data": {"metrics": {"value": 20}}},
+        {"_id": 3, "partition": "A", "data": {"metrics": {"value": 30}}},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$data.metrics.value"
+    )
+    expected = [
+        {"_id": 1, "partition": "A", "data": {"metrics": {"value": 10}}, "result": [10, 20, 30]},
+        {"_id": 2, "partition": "A", "data": {"metrics": {"value": 20}}, "result": [10, 20, 30]},
+        {"_id": 3, "partition": "A", "data": {"metrics": {"value": 30}}, "result": [10, 20, 30]},
+    ]
+    assertSuccess(
+        result, expected, msg="dotted field path collects nested values", ignore_order_in=["result"]
+    )
+
+
+# Property [Missing Intermediate Path]: a missing intermediate path contributes nothing.
+
+
+def test_addToSet_missing_intermediate_path(collection):
+    """$addToSet with a missing intermediate path contributes nothing for that doc."""
+    docs = [
+        {"_id": 1, "partition": "A", "data": {"metrics": {"value": 10}}},
+        {"_id": 2, "partition": "A", "data": {"other": 99}},
+        {"_id": 3, "partition": "A", "data": {"metrics": {"value": 30}}},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$data.metrics.value"
+    )
+    # Doc 2 has no data.metrics.value -> contributes nothing. Set is {10, 30}.
+    expected = [
+        {"_id": 1, "partition": "A", "data": {"metrics": {"value": 10}}, "result": [10, 30]},
+        {"_id": 2, "partition": "A", "data": {"other": 99}, "result": [10, 30]},
+        {"_id": 3, "partition": "A", "data": {"metrics": {"value": 30}}, "result": [10, 30]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="missing intermediate path contributes nothing",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Null-Valued vs Missing]: an explicit null is collected; a missing field is not.
+
+
+def test_addToSet_null_valued_field_collected_missing_skipped(collection):
+    """$addToSet collects an explicit null but skips a missing field."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": None},
+        {"_id": 2, "partition": "A", "v": 10},
+        {"_id": 3, "partition": "A"},
+    ]
+    result = run_window_operator(collection, "$addToSet", docs, WHOLE, expression="$v")
+    # Explicit null collected once; doc 3 (missing v) contributes nothing. Set is {null, 10}.
+    expected = [
+        {"_id": 1, "partition": "A", "v": None, "result": [None, 10]},
+        {"_id": 2, "partition": "A", "v": 10, "result": [None, 10]},
+        {"_id": 3, "partition": "A", "result": [None, 10]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="explicit null collected, missing field skipped",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Top-Level Array Field]: an array value is collected whole as one element.
+
+
+def test_addToSet_top_level_array_collected_whole(collection):
+    """$addToSet collects a top-level array value as a single element; equal arrays dedup."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": [10, 20]},
+        {"_id": 2, "partition": "A", "v": [10, 20]},
+        {"_id": 3, "partition": "A", "v": 50},
+    ]
+    result = run_window_operator(collection, "$addToSet", docs, WHOLE, expression="$v")
+    # The two [10, 20] arrays collapse; 50 is distinct. Set is {[10, 20], 50}.
+    expected = [
+        {"_id": 1, "partition": "A", "v": [10, 20], "result": [[10, 20], 50]},
+        {"_id": 2, "partition": "A", "v": [10, 20], "result": [[10, 20], 50]},
+        {"_id": 3, "partition": "A", "v": 50, "result": [[10, 20], 50]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="top-level array collected whole and deduped",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Array-of-Objects Intermediate Path]: a path through an array of objects returns
+# the array of matched values, collected as one element.
+
+
+def test_addToSet_intermediate_array_path(collection):
+    """$addToSet with a path through an array of objects collects the matched-values array."""
+    docs = [
+        {"_id": 1, "partition": "A", "arr": [{"field": 10}, {"field": 20}]},
+        {"_id": 2, "partition": "A", "arr": [{"field": 30}, {"field": 40}]},
+    ]
+    result = run_window_operator(collection, "$addToSet", docs, WHOLE, expression="$arr.field")
+    # "$arr.field" resolves to [10, 20] and [30, 40] respectively, each collected as one element.
+    expected = [
+        {
+            "_id": 1,
+            "partition": "A",
+            "arr": [{"field": 10}, {"field": 20}],
+            "result": [[10, 20], [30, 40]],
+        },
+        {
+            "_id": 2,
+            "partition": "A",
+            "arr": [{"field": 30}, {"field": 40}],
+            "result": [[10, 20], [30, 40]],
+        },
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="array-of-objects path collects matched-values array",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Numeric Path Component]: a numeric path component in window context.
+
+
+def test_addToSet_numeric_path_component(collection):
+    """$addToSet with a numeric path component collects the (empty) resolved value."""
+    docs = [
+        {"_id": 1, "partition": "A", "arr": [{"field": 10}, {"field": 20}]},
+        {"_id": 2, "partition": "A", "arr": [{"field": 30}, {"field": 40}]},
+    ]
+    result = run_window_operator(collection, "$addToSet", docs, WHOLE, expression="$arr.0.field")
+    # "$arr.0.field" yields an empty array here, collected as one element and deduped across rows.
+    expected = [
+        {"_id": 1, "partition": "A", "arr": [{"field": 10}, {"field": 20}], "result": [[]]},
+        {"_id": 2, "partition": "A", "arr": [{"field": 30}, {"field": 40}], "result": [[]]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="numeric path component collects empty resolved value",
+        ignore_order_in=["result"],
+    )

--- a/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_frame_computation.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_frame_computation.py
@@ -1,0 +1,112 @@
+"""
+Tests for $addToSet computation under documents-mode window frame shapes.
+
+Verifies the correct set given the documents in each frame shape (whole,
+cumulative, reverse-cumulative, sliding) plus the empty-frame result ([]). Input
+has duplicate values so dedup is observable, and the sliding frame shows a value
+leaving the set as its documents exit. Results compared with ignore_order_in=["result"].
+"""
+
+import pytest
+
+from documentdb_tests.compatibility.tests.core.operator.window.utils.window_test_case import (
+    WindowTestCase,
+    run_window_operator,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+from documentdb_tests.framework.parametrize import pytest_params
+
+# Values with duplicates so dedup within each frame is visible.
+FRAME_DOCS = [
+    {"_id": 1, "partition": "A", "value": 10},
+    {"_id": 2, "partition": "A", "value": 10},
+    {"_id": 3, "partition": "A", "value": 20},
+    {"_id": 4, "partition": "A", "value": 30},
+    {"_id": 5, "partition": "A", "value": 20},
+]
+
+EMPTY_FRAME_DOCS = [
+    {"_id": 1, "partition": "A", "value": 10},
+    {"_id": 2, "partition": "A", "value": 20},
+    {"_id": 3, "partition": "A", "value": 30},
+]
+
+ADDTOSET_FRAME_TESTS: list[WindowTestCase] = [
+    # Property [Whole Partition]: unbounded-unbounded frame -> set of all distinct values.
+    WindowTestCase(
+        "whole_partition",
+        docs=FRAME_DOCS,
+        window={"documents": ["unbounded", "unbounded"]},
+        expected=[
+            {"_id": 1, "partition": "A", "value": 10, "result": [10, 20, 30]},
+            {"_id": 2, "partition": "A", "value": 10, "result": [10, 20, 30]},
+            {"_id": 3, "partition": "A", "value": 20, "result": [10, 20, 30]},
+            {"_id": 4, "partition": "A", "value": 30, "result": [10, 20, 30]},
+            {"_id": 5, "partition": "A", "value": 20, "result": [10, 20, 30]},
+        ],
+        msg="whole partition -> set of all distinct values",
+    ),
+    # Property [Cumulative Frame]: expanding frame from start to current; set grows with dedup.
+    WindowTestCase(
+        "cumulative",
+        docs=FRAME_DOCS,
+        window={"documents": ["unbounded", "current"]},
+        expected=[
+            {"_id": 1, "partition": "A", "value": 10, "result": [10]},
+            {"_id": 2, "partition": "A", "value": 10, "result": [10]},
+            {"_id": 3, "partition": "A", "value": 20, "result": [10, 20]},
+            {"_id": 4, "partition": "A", "value": 30, "result": [10, 20, 30]},
+            {"_id": 5, "partition": "A", "value": 20, "result": [10, 20, 30]},
+        ],
+        msg="cumulative frame -> expanding deduplicated set",
+    ),
+    # Property [Reverse Cumulative Frame]: shrinking frame from current to end.
+    WindowTestCase(
+        "reverse_cumulative",
+        docs=FRAME_DOCS,
+        window={"documents": ["current", "unbounded"]},
+        expected=[
+            {"_id": 1, "partition": "A", "value": 10, "result": [10, 20, 30]},
+            {"_id": 2, "partition": "A", "value": 10, "result": [10, 20, 30]},
+            {"_id": 3, "partition": "A", "value": 20, "result": [20, 30]},
+            {"_id": 4, "partition": "A", "value": 30, "result": [20, 30]},
+            {"_id": 5, "partition": "A", "value": 20, "result": [20]},
+        ],
+        msg="reverse-cumulative frame -> shrinking deduplicated set",
+    ),
+    # Property [Sliding Frame]: fixed-size window; demonstrates removal as values exit the frame.
+    WindowTestCase(
+        "sliding_centered",
+        docs=FRAME_DOCS,
+        window={"documents": [-1, 1]},
+        expected=[
+            {"_id": 1, "partition": "A", "value": 10, "result": [10]},
+            {"_id": 2, "partition": "A", "value": 10, "result": [10, 20]},
+            {"_id": 3, "partition": "A", "value": 20, "result": [10, 20, 30]},
+            {"_id": 4, "partition": "A", "value": 30, "result": [20, 30]},
+            {"_id": 5, "partition": "A", "value": 20, "result": [20, 30]},
+        ],
+        msg="centered sliding window [-1,1]; value 10 leaves the set as its docs exit the frame",
+    ),
+    # Property [Empty Frame]: a frame selecting no documents -> [].
+    WindowTestCase(
+        "empty_frame",
+        docs=EMPTY_FRAME_DOCS,
+        window={"documents": [-3, -2]},
+        expected=[
+            {"_id": 1, "partition": "A", "value": 10, "result": []},
+            {"_id": 2, "partition": "A", "value": 20, "result": []},
+            {"_id": 3, "partition": "A", "value": 30, "result": [10]},
+        ],
+        msg="empty frame -> [] (early rows select no documents)",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", pytest_params(ADDTOSET_FRAME_TESTS))
+def test_addToSet_documents_frames(collection, test):
+    """$addToSet with various documents-mode window frames produces the correct set."""
+    result = run_window_operator(
+        collection, "$addToSet", test.docs, test.window, sort_by=test.sort_by
+    )
+    assertSuccess(result, test.expected, msg=test.msg, ignore_order_in=["result"])

--- a/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_order_independence.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_order_independence.py
@@ -1,0 +1,66 @@
+"""
+Tests for $addToSet order independence in window context.
+
+Verifies $addToSet yields the same whole-partition set regardless of sortBy
+direction. Uses distinct values (no cross-type numeric equivalence, whose kept
+representation depends on sort order). Results compared with ignore_order_in=["result"].
+"""
+
+from documentdb_tests.compatibility.tests.core.operator.window.utils.window_test_case import (
+    BASIC_DOCS,
+    run_window_operator,
+)
+from documentdb_tests.framework.assertions import assertSuccess
+
+WHOLE = {"documents": ["unbounded", "unbounded"]}
+PROJECT_RESULT = [{"$sort": {"_id": 1}}, {"$project": {"_id": 1, "result": 1}}]
+
+# Property [Order Independence]: $addToSet yields the same whole-partition set for any sort order.
+
+
+def test_addToSet_whole_partition_ascending_sort(collection):
+    """$addToSet whole partition with ascending sort produces the full set."""
+    result = run_window_operator(
+        collection,
+        "$addToSet",
+        BASIC_DOCS,
+        WHOLE,
+        sort_by={"_id": 1},
+        extra_stages=PROJECT_RESULT,
+    )
+    expected = [
+        {"_id": 1, "result": [10, 20, 30, 40, 50]},
+        {"_id": 2, "result": [10, 20, 30, 40, 50]},
+        {"_id": 3, "result": [10, 20, 30, 40, 50]},
+        {"_id": 4, "result": [10, 20, 30, 40, 50]},
+        {"_id": 5, "result": [10, 20, 30, 40, 50]},
+    ]
+    assertSuccess(
+        result, expected, msg="ascending sort produces the full set", ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_whole_partition_descending_sort(collection):
+    """$addToSet whole partition with descending sort produces the same set as ascending."""
+    result = run_window_operator(
+        collection,
+        "$addToSet",
+        BASIC_DOCS,
+        WHOLE,
+        sort_by={"_id": -1},
+        extra_stages=PROJECT_RESULT,
+    )
+    # Same set regardless of sort direction — order-independent operator.
+    expected = [
+        {"_id": 1, "result": [10, 20, 30, 40, 50]},
+        {"_id": 2, "result": [10, 20, 30, 40, 50]},
+        {"_id": 3, "result": [10, 20, 30, 40, 50]},
+        {"_id": 4, "result": [10, 20, 30, 40, 50]},
+        {"_id": 5, "result": [10, 20, 30, 40, 50]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="descending sort produces the same set — order independent",
+        ignore_order_in=["result"],
+    )

--- a/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_set_semantics.py
+++ b/documentdb_tests/compatibility/tests/core/operator/window/addToSet/test_window_addToSet_set_semantics.py
@@ -1,0 +1,390 @@
+"""
+Tests for $addToSet set semantics in window context — the core behavior.
+
+Covers deduplication (including sliding-window removal and reappearance),
+numeric equivalence coalescing, BSON type distinction, null vs missing, document
+and array deep equality, mixed BSON types, and NaN-as-a-set-element. Results
+compared with ignore_order_in=["result"].
+"""
+
+from datetime import datetime, timezone
+
+from bson import Decimal128, Int64, MaxKey, MinKey, ObjectId, Regex, Timestamp
+
+from documentdb_tests.compatibility.tests.core.operator.window.utils.window_test_case import (
+    run_window_operator,
+)
+from documentdb_tests.framework.assertions import assertSuccess, assertSuccessNaN
+
+WHOLE = {"documents": ["unbounded", "unbounded"]}
+# Whole-partition frames give every row the same set; project one row for a concise assertion.
+FIRST_ROW = [{"$sort": {"_id": 1}}, {"$limit": 1}, {"$project": {"_id": 0, "result": 1}}]
+ALL_ROWS = [{"$sort": {"_id": 1}}, {"$project": {"_id": 1, "result": 1}}]
+
+
+# Property [Deduplication under Sliding Window]: values dedup within the frame; a value leaves
+# the set when its doc exits the frame and can reappear later.
+
+
+def test_addToSet_dedup_sliding_window_removal_and_reappear(collection):
+    """$addToSet dedups within a sliding frame; a value leaves and later reappears."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": 1},
+        {"_id": 2, "partition": "A", "v": 2},
+        {"_id": 3, "partition": "A", "v": 3},
+        {"_id": 4, "partition": "A", "v": 1},
+    ]
+    result = run_window_operator(
+        collection,
+        "$addToSet",
+        docs,
+        {"documents": [-1, 0]},
+        expression="$v",
+        extra_stages=ALL_ROWS,
+    )
+    # Window [-1,0] = previous + current. Value 1 present at _id1, gone at _id2/_id3, back at _id4.
+    expected = [
+        {"_id": 1, "result": [1]},
+        {"_id": 2, "result": [1, 2]},
+        {"_id": 3, "result": [2, 3]},
+        {"_id": 4, "result": [1, 3]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="sliding-window dedup with removal and reappearance",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Numeric Equivalence Coalescing]: numerically equal values across types collapse to one.
+
+
+def test_addToSet_numeric_coalescing_collapses(collection):
+    """$addToSet collapses numerically-equal values across types into one element."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": 1},
+        {"_id": 2, "partition": "A", "v": Int64(1)},
+        {"_id": 3, "partition": "A", "v": 1.0},
+        {"_id": 4, "partition": "A", "v": Decimal128("1")},
+        {"_id": 5, "partition": "A", "v": 2},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    # int1 / long1 / double1.0 / decimal1 all coalesce to one element; the kept representation
+    # is the first encountered under the _id:1 sort (int32 here).
+    expected = [{"result": [1, 2]}]
+    assertSuccess(
+        result,
+        expected,
+        msg="numeric equivalents coalesce to one element",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [BSON Type Distinction]: booleans are distinct from numbers (false != 0, true != 1).
+
+
+def test_addToSet_bool_vs_number_distinct(collection):
+    """$addToSet keeps booleans distinct from numerically-equal integers."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": False},
+        {"_id": 2, "partition": "A", "v": 0},
+        {"_id": 3, "partition": "A", "v": True},
+        {"_id": 4, "partition": "A", "v": 1},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [False, 0, True, 1]}]
+    assertSuccess(
+        result,
+        expected,
+        msg="false!=0 and true!=1 — four distinct elements",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Null vs Missing]: an explicit null is collected; a missing field contributes nothing.
+
+
+def test_addToSet_null_collected_missing_skipped(collection):
+    """$addToSet collects an explicit null once and skips a missing field."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": None},
+        {"_id": 2, "partition": "A"},
+        {"_id": 3, "partition": "A", "v": None},
+        {"_id": 4, "partition": "A", "v": 5},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [None, 5]}]
+    assertSuccess(
+        result,
+        expected,
+        msg="explicit null collected once, missing skipped",
+        ignore_order_in=["result"],
+    )
+
+
+def test_addToSet_all_missing_frame_empty(collection):
+    """$addToSet over a frame where every doc is missing the field returns []."""
+    docs = [
+        {"_id": 1, "partition": "A"},
+        {"_id": 2, "partition": "A"},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": []}]
+    assertSuccess(result, expected, msg="all-missing frame returns []", ignore_order_in=["result"])
+
+
+# Property [Document Deep Equality]: identical documents collapse; differing ones stay distinct.
+
+
+def test_addToSet_document_exact_duplicates_collapse(collection):
+    """$addToSet collapses identical documents and keeps documents that differ."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": {"a": 1, "b": 2}},
+        {"_id": 2, "partition": "A", "v": {"a": 1, "b": 2}},
+        {"_id": 3, "partition": "A", "v": {"a": 1, "b": 3}},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [{"a": 1, "b": 2}, {"a": 1, "b": 3}]}]
+    assertSuccess(
+        result,
+        expected,
+        msg="identical documents collapse, differing ones distinct",
+        ignore_order_in=["result"],
+    )
+
+
+def test_addToSet_document_field_order_distinct(collection):
+    """$addToSet treats documents with different field order as distinct elements."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": {"a": 1, "b": 2}},
+        {"_id": 2, "partition": "A", "v": {"b": 2, "a": 1}},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    # {a:1,b:2} and {b:2,a:1} are distinct elements (field order matters) — two elements.
+    expected = [{"result": [{"a": 1, "b": 2}, {"b": 2, "a": 1}]}]
+    assertSuccess(
+        result,
+        expected,
+        msg="documents with different field order are distinct",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Array Deep Equality]: element order matters; identical arrays collapse.
+
+
+def test_addToSet_array_element_order_distinct(collection):
+    """$addToSet keeps arrays with different element order distinct; identical ones collapse."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": [1, 2]},
+        {"_id": 2, "partition": "A", "v": [2, 1]},
+        {"_id": 3, "partition": "A", "v": [1, 2]},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [[1, 2], [2, 1]]}]
+    assertSuccess(
+        result,
+        expected,
+        msg="[1,2] and [2,1] are distinct; duplicate [1,2] collapses",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [Mixed BSON Types]: values of any type accumulate; duplicates collapse.
+
+
+def test_addToSet_mixed_bson_types_accumulate(collection):
+    """$addToSet accumulates mixed BSON types and dedups duplicates."""
+    date_val = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    oid = ObjectId("64000000000000000000000a")
+    docs = [
+        {"_id": 1, "partition": "A", "v": "x"},
+        {"_id": 2, "partition": "A", "v": "x"},
+        {"_id": 3, "partition": "A", "v": True},
+        {"_id": 4, "partition": "A", "v": date_val},
+        {"_id": 5, "partition": "A", "v": oid},
+        {"_id": 6, "partition": "A", "v": {"nested": [1, 2]}},
+        {"_id": 7, "partition": "A", "v": Timestamp(1, 1)},
+        {"_id": 8, "partition": "A", "v": MinKey()},
+        {"_id": 9, "partition": "A", "v": MaxKey()},
+        {"_id": 10, "partition": "A", "v": Regex("abc", "i")},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    # "x" collapses; all other types are distinct elements.
+    expected = [
+        {
+            "result": [
+                "x",
+                True,
+                date_val,
+                oid,
+                {"nested": [1, 2]},
+                Timestamp(1, 1),
+                MinKey(),
+                MaxKey(),
+                Regex("abc", "i"),
+            ]
+        }
+    ]
+    assertSuccess(
+        result, expected, msg="mixed BSON types accumulate with dedup", ignore_order_in=["result"]
+    )
+
+
+# Property [Value Distinction]: values that look similar across types stay distinct.
+
+
+def test_addToSet_string_vs_number_distinct(collection):
+    """$addToSet keeps the string "1" distinct from the number 1."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": "1"},
+        {"_id": 2, "partition": "A", "v": 1},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": ["1", 1]}]
+    assertSuccess(
+        result, expected, msg='string "1" is distinct from number 1', ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_signed_zero_collapses(collection):
+    """$addToSet collapses 0, -0.0, and 0.0 into a single element."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": 0},
+        {"_id": 2, "partition": "A", "v": -0.0},
+        {"_id": 3, "partition": "A", "v": 0.0},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [0]}]
+    assertSuccess(
+        result, expected, msg="signed/typed zeros collapse to one", ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_infinities_distinct(collection):
+    """$addToSet keeps +Infinity and -Infinity distinct; duplicate +Infinity collapses."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": float("inf")},
+        {"_id": 2, "partition": "A", "v": float("-inf")},
+        {"_id": 3, "partition": "A", "v": float("inf")},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [float("inf"), float("-inf")]}]
+    assertSuccess(
+        result, expected, msg="+Infinity and -Infinity are distinct", ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_empty_values_all_distinct(collection):
+    """$addToSet keeps "", [], {}, null, and 0 as five distinct elements."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": ""},
+        {"_id": 2, "partition": "A", "v": []},
+        {"_id": 3, "partition": "A", "v": {}},
+        {"_id": 4, "partition": "A", "v": None},
+        {"_id": 5, "partition": "A", "v": 0},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": ["", [], {}, None, 0]}]
+    assertSuccess(
+        result, expected, msg='"", [], {}, null, 0 are all distinct', ignore_order_in=["result"]
+    )
+
+
+def test_addToSet_empty_array_vs_null_distinct(collection):
+    """$addToSet keeps an empty array distinct from null; identical empty arrays collapse."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": []},
+        {"_id": 2, "partition": "A", "v": None},
+        {"_id": 3, "partition": "A", "v": []},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    expected = [{"result": [[], None]}]
+    assertSuccess(
+        result, expected, msg="empty array is distinct from null", ignore_order_in=["result"]
+    )
+
+
+# Property [Multiplicity]: a value stays while >=1 in-frame doc carries it (no inverse;
+# the set is recomputed per frame), vanishing only when its last occurrence leaves.
+
+
+def test_addToSet_value_persists_until_last_occurrence_leaves(collection):
+    """$addToSet keeps a value while any in-frame doc has it; it leaves with the last one."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": "a"},
+        {"_id": 2, "partition": "A", "v": "a"},
+        {"_id": 3, "partition": "A", "v": "b"},
+        {"_id": 4, "partition": "A", "v": "c"},
+        {"_id": 5, "partition": "A", "v": "d"},
+    ]
+    result = run_window_operator(
+        collection,
+        "$addToSet",
+        docs,
+        {"documents": [-2, 0]},
+        expression="$v",
+        extra_stages=ALL_ROWS,
+    )
+    # At _id4 the frame is rows 2-4 (a,b,c): _id1's "a" slid out but "a" stays via _id2.
+    # At _id5 the frame is rows 3-5 (b,c,d): both "a"s are gone.
+    expected = [
+        {"_id": 1, "result": ["a"]},
+        {"_id": 2, "result": ["a"]},
+        {"_id": 3, "result": ["a", "b"]},
+        {"_id": 4, "result": ["a", "b", "c"]},
+        {"_id": 5, "result": ["b", "c", "d"]},
+    ]
+    assertSuccess(
+        result,
+        expected,
+        msg="value persists until its last in-frame occurrence leaves",
+        ignore_order_in=["result"],
+    )
+
+
+# Property [NaN as Element]: two NaNs collapse to a single element.
+
+
+def test_addToSet_nan_collapses(collection):
+    """$addToSet collapses duplicate NaN values into a single element."""
+    docs = [
+        {"_id": 1, "partition": "A", "v": float("nan")},
+        {"_id": 2, "partition": "A", "v": float("nan")},
+        {"_id": 3, "partition": "A", "v": 1.0},
+    ]
+    result = run_window_operator(
+        collection, "$addToSet", docs, WHOLE, expression="$v", extra_stages=FIRST_ROW
+    )
+    # Two NaNs collapse to one; 1.0 is kept as a double.
+    expected = [{"result": [float("nan"), 1.0]}]
+    assertSuccessNaN(
+        result, expected, msg="duplicate NaN collapses to one element", ignore_order_in=["result"]
+    )


### PR DESCRIPTION
Add per-operator MongoDB-compatibility tests for the $addToSet window operator under $setWindowFields: argument validation, documents-mode frame computation, order independence, field paths, and set semantics (dedup, numeric equivalence coalescing, null vs missing, document/array deep equality, mixed BSON types, and NaN). 41 cases, validated against MongoDB 8.2.4. Results are compared as sets since $addToSet output order is unspecified.